### PR TITLE
Nabeel/36 additional plan builder features

### DIFF
--- a/server/mongodb/actions/Plan.ts
+++ b/server/mongodb/actions/Plan.ts
@@ -4,42 +4,44 @@ import Plan from "../models/Plan";
 import { Plan as PlanType } from "src/utils/types";
 
 export async function createPlan(plan: PlanType) {
-    await mongoDB();
-    
-    const newPlan = await Plan.create(plan, function (err, docs) {
-        if (err){
-            console.log(err)
-        }
-        else {
-            console.log("Created Plan: ", docs);
-        }
-    });
+  await mongoDB();
 
-    return newPlan;
+  const newPlan = await Plan.create(plan, function (err, docs) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log("Created Plan: ", docs);
+    }
+  });
+
+  return newPlan;
 }
 
-export async function updatePlanById(id: string, updatedPlan: Partial<PlanType>) {
-    await mongoDB();
+export async function updatePlanById(
+  id: string,
+  updatedPlan: Partial<PlanType>
+) {
+  await mongoDB();
 
-    await Plan.findOneAndUpdate({_id: id}, updatedPlan);
+  await Plan.findOneAndUpdate({ _id: id }, updatedPlan);
 }
 
 export async function deletePlanById(id: string) {
-    await mongoDB();
+  await mongoDB();
 
-    await Plan.findOneAndRemove({_id: id });
+  await Plan.findOneAndRemove({ _id: id });
 }
 
 export async function getPlanById(id: string) {
-    await mongoDB();
+  await mongoDB();
 
-    const plan = await Plan.find({_id: id});
+  const plan = await Plan.find({ _id: id });
 
-    return plan;
+  return plan;
 }
 
 export async function getPlans(userId: string) {
-    await mongoDB();
+  await mongoDB();
 
-    return Plan.find({userId: userId});
+  return Plan.find({ userId: userId });
 }

--- a/server/mongodb/models/Plan.js
+++ b/server/mongodb/models/Plan.js
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import { Card } from "src/utils/types.ts";
+import { CardSchema as Card } from "./Card";
 
 const { Schema } = mongoose;
 
@@ -9,7 +9,7 @@ const PlanSchema = new Schema({
   },
   cards: {
     type: [Card],
-  }, 
+  },
   name: {
     type: String,
   },

--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -108,7 +108,13 @@ const CardModal = ({
       </>
     );
   };
-
+  const {
+    AddToPlanButton = (
+      <Button bgColor="#D9D9D9" alignSelf="end" size="lg" rounded={16}>
+        Add to Plan
+      </Button>
+    ),
+  } = { ...rest };
   return (
     <Modal
       {...rest}
@@ -275,9 +281,7 @@ const CardModal = ({
                   </Box>
                 </Center>
               )}
-              <Button bgColor="#D9D9D9" alignSelf="end" size="lg" rounded={16}>
-                Add to Plan
-              </Button>
+              {AddToPlanButton}
             </SimpleGrid>
           </Flex>
         </ModalBody>

--- a/src/components/Modals/PlanConfirmationModal/PlanConfirmationModal.jsx
+++ b/src/components/Modals/PlanConfirmationModal/PlanConfirmationModal.jsx
@@ -1,0 +1,30 @@
+import {
+  Button,
+  Center,
+  HStack,
+  Modal,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react";
+
+export default function PlanConfirmationModal(props) {
+  const { onClose, isOpen, handleSave, handleDiscard } = { ...props };
+  return (
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>End Project Plan</ModalHeader>
+        <ModalCloseButton />
+        <Center m="25%" fontSize="xl">
+          Do you want to save this project plan before marking it as complete?
+        </Center>
+        <HStack justify="space-evenly" p={3}>
+          <Button onClick={handleSave}>Yes, save project plan</Button>
+          <Button onClick={handleDiscard}>No, discard project plan</Button>
+        </HStack>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/Modals/PlanConfirmationModal/index.js
+++ b/src/components/Modals/PlanConfirmationModal/index.js
@@ -1,0 +1,3 @@
+import PlanConfirmationModal from "./PlanConfirmationModal";
+
+export default PlanConfirmationModal;

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -129,6 +129,7 @@ const StandardCard = ({ card, ...props }) => {
           cardTitle={card.title}
           cardComments={card.comments}
           cardImages={card.images}
+          AddToPlanButton={<SelectorButton />}
         />
       </Flex>
     </Flex>

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -7,27 +7,49 @@ import {
   HStack,
   Tag,
   useDisclosure,
+  Icon,
+  Box,
 } from "@chakra-ui/react";
 import CardModal from "../Modals/CardModal";
 import Comments from "../Comments";
+import { CheckIcon } from "@chakra-ui/icons";
 
 const StandardCard = ({ card, ...props }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
+  const { setSelection = () => undefined } = { ...card };
   return (
     <Flex
       {...props}
       flexDirection="column"
       boxShadow="base"
+      bgColor="white"
       height={{ base: "sm", md: "md" }}
+      borderColor="green.500"
+      borderWidth={card.selected ? "5px" : "0"}
+      onClick={() => setSelection(!card.selected)}
     >
-      <Image
-        height="37%"
-        width="full"
-        fit="cover"
-        src={card.images[0]}
-        alt="construction image"
-      />
+      <Box height="37%" position="relative">
+        {card.selected && (
+          <Icon
+            bgColor="green.500"
+            color="white"
+            borderRadius="100%"
+            p="1"
+            as={CheckIcon}
+            position="absolute"
+            fontSize="24"
+            left="5"
+            top="5"
+          />
+        )}
+        <Image
+          height="100%"
+          width="full"
+          fit="cover"
+          src={card.images[0]}
+          alt="construction image"
+        />
+      </Box>
 
       <Flex p={3} flexDirection="column" flex={1}>
         <Heading size="md">{card.title}</Heading>

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -34,6 +34,15 @@ const StandardCard = ({ card, ...props }) => {
     switchGray: RepeatIcon,
     switchYellow: RepeatIcon,
   };
+  const SelectorButton = () => (
+    <Button
+      disabled={mode === "switchYellow" || mode === "switchGray"}
+      onClick={() => setSelection(!card.selected)}
+      flex="1"
+    >
+      {card.selected ? "Remove from plan" : "Add to Plan"}
+    </Button>
+  );
 
   return (
     <Flex

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -9,14 +9,19 @@ import {
   useDisclosure,
   Icon,
   Box,
+  IconButton,
 } from "@chakra-ui/react";
 import CardModal from "../Modals/CardModal";
 import Comments from "../Comments";
-import { CheckIcon, CloseIcon, RepeatIcon } from "@chakra-ui/icons";
+import { CheckIcon, CloseIcon, InfoIcon, RepeatIcon } from "@chakra-ui/icons";
 
 const StandardCard = ({ card, ...props }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { setSelection = () => undefined, mode = "green" } = { ...card };
+  const {
+    setSelection = () => undefined,
+    mode = "green",
+    selectable = false,
+  } = { ...card };
   const modeColors = {
     green: "green.500",
     red: "red.500",
@@ -45,10 +50,14 @@ const StandardCard = ({ card, ...props }) => {
           ? "5px"
           : "0"
       }
-      onClick={() => setSelection(!card.selected)}
+      onClick={
+        mode === "switchYellow" || mode === "switchGray"
+          ? () => setSelection(!card.selected)
+          : () => undefined
+      }
     >
       <Box height="37%" position="relative">
-        {card.selected && (
+        {card.selected && mode !== "red" && (
           <Icon
             bgColor={modeColors[mode]}
             color="white"
@@ -88,9 +97,20 @@ const StandardCard = ({ card, ...props }) => {
             );
           })}
         </HStack>
-        <Button size="lg" mt={7} onClick={onOpen} bgColor="#D9D9D9">
-          View Full Standard
-        </Button>
+        {selectable ? (
+          <HStack justify="space-evenly" pt="5">
+            <SelectorButton />
+            <IconButton
+              onClick={onOpen}
+              fontSize="lg"
+              icon={<Icon as={InfoIcon} />}
+            ></IconButton>
+          </HStack>
+        ) : (
+          <Button size="lg" mt={7} onClick={onOpen} bgColor="#D9D9D9">
+            View Full Standard
+          </Button>
+        )}
         <CardModal
           isOpen={isOpen}
           onClose={onClose}

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -12,11 +12,11 @@ import {
 } from "@chakra-ui/react";
 import CardModal from "../Modals/CardModal";
 import Comments from "../Comments";
-import { CheckIcon } from "@chakra-ui/icons";
+import { CheckIcon, CloseIcon } from "@chakra-ui/icons";
 
 const StandardCard = ({ card, ...props }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { setSelection = () => undefined } = { ...card };
+  const { setSelection = () => undefined, toDeselect = false } = { ...card };
   return (
     <Flex
       {...props}
@@ -25,23 +25,36 @@ const StandardCard = ({ card, ...props }) => {
       bgColor="white"
       height={{ base: "sm", md: "md" }}
       borderColor="green.500"
-      borderWidth={card.selected ? "5px" : "0"}
+      borderWidth={card.selected && !card.toDeselect ? "5px" : "0"}
       onClick={() => setSelection(!card.selected)}
     >
       <Box height="37%" position="relative">
-        {card.selected && (
-          <Icon
-            bgColor="green.500"
-            color="white"
-            borderRadius="100%"
-            p="1"
-            as={CheckIcon}
-            position="absolute"
-            fontSize="24"
-            left="5"
-            top="5"
-          />
-        )}
+        {card.selected &&
+          (toDeselect ? (
+            <Icon
+              bgColor="red.500"
+              color="white"
+              borderRadius="100%"
+              p="1"
+              as={CloseIcon}
+              position="absolute"
+              fontSize="24"
+              left="5"
+              top="5"
+            />
+          ) : (
+            <Icon
+              bgColor="green.500"
+              color="white"
+              borderRadius="100%"
+              p="1"
+              as={CheckIcon}
+              position="absolute"
+              fontSize="24"
+              left="5"
+              top="5"
+            />
+          ))}
         <Image
           height="100%"
           width="full"

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -12,11 +12,24 @@ import {
 } from "@chakra-ui/react";
 import CardModal from "../Modals/CardModal";
 import Comments from "../Comments";
-import { CheckIcon, CloseIcon } from "@chakra-ui/icons";
+import { CheckIcon, CloseIcon, RepeatIcon } from "@chakra-ui/icons";
 
 const StandardCard = ({ card, ...props }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { setSelection = () => undefined, toDeselect = false } = { ...card };
+  const { setSelection = () => undefined, mode = "green" } = { ...card };
+  const modeColors = {
+    green: "green.500",
+    red: "red.500",
+    switchGray: "gray.500",
+    switchYellow: "yellow.500",
+  };
+  const modeIcons = {
+    green: CheckIcon,
+    red: CloseIcon,
+    switchGray: RepeatIcon,
+    switchYellow: RepeatIcon,
+  };
+
   return (
     <Flex
       {...props}
@@ -24,37 +37,30 @@ const StandardCard = ({ card, ...props }) => {
       boxShadow="base"
       bgColor="white"
       height={{ base: "sm", md: "md" }}
-      borderColor="green.500"
-      borderWidth={card.selected && !card.toDeselect ? "5px" : "0"}
+      borderColor={
+        mode === "switchYellow" ? modeColors.switchYellow : "green.500"
+      }
+      borderWidth={
+        card.selected && (mode === "green" || mode === "switchYellow")
+          ? "5px"
+          : "0"
+      }
       onClick={() => setSelection(!card.selected)}
     >
       <Box height="37%" position="relative">
-        {card.selected &&
-          (toDeselect ? (
-            <Icon
-              bgColor="red.500"
-              color="white"
-              borderRadius="100%"
-              p="1"
-              as={CloseIcon}
-              position="absolute"
-              fontSize="24"
-              left="5"
-              top="5"
-            />
-          ) : (
-            <Icon
-              bgColor="green.500"
-              color="white"
-              borderRadius="100%"
-              p="1"
-              as={CheckIcon}
-              position="absolute"
-              fontSize="24"
-              left="5"
-              top="5"
-            />
-          ))}
+        {card.selected && (
+          <Icon
+            bgColor={modeColors[mode]}
+            color="white"
+            borderRadius="100%"
+            p="1"
+            as={modeIcons[mode]}
+            position="absolute"
+            fontSize="24"
+            left="5"
+            top="5"
+          />
+        )}
         <Image
           height="100%"
           width="full"

--- a/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
+++ b/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
@@ -1,7 +1,15 @@
 import SearchBar, { useSearch } from "../../components/SearchBar";
 import StandardCard from "../../components/StandardCard";
 import { getCards } from "../../actions/Card";
-import { Button, HStack, Heading, Flex, Box, Grid } from "@chakra-ui/react";
+import {
+  Button,
+  HStack,
+  Heading,
+  Flex,
+  Box,
+  Grid,
+  useDisclosure,
+} from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { PDFDownloadLink } from "@react-pdf/renderer";
 import PlanDocumentPDF from "../../components/PlanDocumentPDF/PlanDocumentPDF";
@@ -16,8 +24,7 @@ export default function ProjectPlanBuilder() {
     }); // for the love of God don't put dependency array here
   }, []);
 
-  // Wraps card object with additional properties for setting selection
-  // and vice-versa
+  // Wraps cards with selection info
   const WrapToSelection = (card, index) => {
     return {
       cardProps: card,
@@ -43,38 +50,14 @@ export default function ProjectPlanBuilder() {
     };
   };
 
-  // Handles export logic
-  const ExportHandler = () => {
-    const exportedCards = selections
-      .filter((card) => card.selection)
-      .map(UnwrapToCard);
-    console.log(exportedCards);
-    // exportedCards.forEach(async (card) => {
-    //   await createCard(card);
-    //   console.log("Created " + card);
-    // });
-    alert("Exported data has been logged in console");
-  };
-
-  const SavePlanHandler = async () => {
-    const selectedCards = selections
-      .filter((card) => card.selection)
-      .map(UnwrapToCard);
-    await createPlan({
-      cards: selectedCards,
-      name: "Random Plan",
-      userId: "12345678910",
-    });
-  };
-
-  // Maps selection objects into renderable cards
+  // Array map methods for rendering
   const RenderCards = (card) => {
     const cardProps = { ...card.cardProps };
     cardProps.selected = card.selection;
     cardProps.setSelection = SelectionSetter(card.index);
     return <StandardCard key={card.index} card={cardProps} />;
   };
-
+  // Renders cards to appear de-selectable
   const RenderSelected = (card) => {
     const cardProps = { ...card.cardProps };
     cardProps.selected = card.selection;
@@ -83,7 +66,21 @@ export default function ProjectPlanBuilder() {
     return <StandardCard key={card.index} card={cardProps} />;
   };
 
-  // Filtering logic
+  // DB action handlers
+  const DeleteHandler = () => undefined;
+
+  const SavePlanHandler = async () => {
+    const selectedCards = selections
+      .filter((card) => card.selection)
+      .map(UnwrapToCard);
+    // await createPlan({
+    //   cards: selectedCards,
+    //   name: "Random Plan",
+    //   userId: "12345678910",
+    // });
+  };
+
+  // Search logic
   const { searchedCards, handleSearch } = useSearch(
     selections.map(UnwrapToCard)
   );
@@ -91,6 +88,9 @@ export default function ProjectPlanBuilder() {
   // For PDF exporting
   const [hasLoaded, setHasLoaded] = useState(false);
   useEffect(() => setHasLoaded(true), []);
+
+  // Confimation modal
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
       <Flex flexFlow="row nowrap" mb="10">
@@ -139,11 +139,11 @@ export default function ProjectPlanBuilder() {
                 )}
               </PDFDownloadLink>
             )}
+            <Button onClick={DeleteHandler}>Delete</Button>
             <Button onClick={SavePlanHandler} bg="gold" color="white">
               Save Project Plan
             </Button>
           </HStack>
-          {/* <Button onClick={ExportHandler}>Export Selected</Button> */}
         </Flex>
         {selections.filter((card) => card.selection).length > 0 ? (
           <HStack mt="10" gap="41" flexDirection="row">

--- a/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
+++ b/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
@@ -1,6 +1,6 @@
 import SearchBar, { useSearch } from "../../components/SearchBar";
 import { SelectableCard } from "../../components/StandardCard";
-import { getCards } from "../../actions/Card";
+import { createCard, getCards } from "../../actions/Card";
 import { Button, HStack, Heading, Flex, Box, Grid } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { PDFDownloadLink } from "@react-pdf/renderer";
@@ -47,6 +47,17 @@ export default function ProjectPlanBuilder() {
     //   console.log("Created " + card);
     // });
     alert("Exported data has been logged in console");
+  };
+
+  const SavePlanHandler = async () => {
+    const selectedCards = selections
+      .filter((card) => card.selection)
+      .map(UnwrapToCard);
+    await createCard({
+      cards: selectedCards,
+      name: "Random Plan",
+      userId: "12345678910",
+    });
   };
 
   // Maps selection objects into renderable cards
@@ -100,7 +111,7 @@ export default function ProjectPlanBuilder() {
         >
           <Heading size="lg">Current Project Plan</Heading>
           <HStack>
-            <Button>Download</Button>
+            {/* <Button>Download</Button> */}
             {hasLoaded && (
               <PDFDownloadLink
                 document={
@@ -117,11 +128,11 @@ export default function ProjectPlanBuilder() {
                 )}
               </PDFDownloadLink>
             )}
-            <Button bg="gold" color="white">
-              End Project Plan
+            <Button onClick={SavePlanHandler} bg="gold" color="white">
+              Save Project Plan
             </Button>
           </HStack>
-          <Button onClick={ExportHandler}>Export Selected</Button>
+          {/* <Button onClick={ExportHandler}>Export Selected</Button> */}
         </Flex>
         {selections.filter((card) => card.selection).length > 0 ? (
           <HStack mt="10" gap="41" flexDirection="row">

--- a/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
+++ b/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
@@ -17,6 +17,7 @@ import PlanDocumentPDF from "../../components/PlanDocumentPDF/PlanDocumentPDF";
 import { createPlan } from "../../actions/Plan";
 import PlanConfirmationModal from "../../components/Modals/PlanConfirmationModal";
 import { EditIcon, Icon } from "@chakra-ui/icons";
+import useUser from "../../utils/lib/useUser";
 
 export default function ProjectPlanBuilder() {
   // Primary state in this page is the selections array
@@ -81,15 +82,30 @@ export default function ProjectPlanBuilder() {
     onClose();
   };
 
+  const removeExtraProps = (card) => {
+    const newCard = { ...card };
+    if (newCard.selected !== undefined) {
+      delete newCard.selected;
+    }
+    if (newCard.setSelection !== undefined) {
+      delete newCard.setSelection;
+    }
+    if (newCard.selectionIndex !== undefined) {
+      delete newCard.selectionIndex;
+    }
+    return newCard;
+  };
+
   const SavePlanHandler = async () => {
     const selectedCards = selections
       .filter((card) => card.selection)
-      .map(UnwrapToCard);
-    // await createPlan({
-    //   cards: selectedCards,
-    //   name: "Random Plan",
-    //   userId: "12345678910",
-    // });
+      .map(UnwrapToCard)
+      .map(removeExtraProps);
+    await createPlan({
+      cards: selectedCards,
+      name: nameRef.current.value,
+      userId: user._id,
+    });
     onClose();
   };
 
@@ -105,6 +121,7 @@ export default function ProjectPlanBuilder() {
   // Confimation modal
   const { isOpen, onOpen, onClose } = useDisclosure();
   const nameRef = useRef();
+  const { user } = useUser();
 
   return (
     <>

--- a/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
+++ b/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
@@ -1,5 +1,5 @@
 import SearchBar, { useSearch } from "../../components/SearchBar";
-import { SelectableCard } from "../../components/StandardCard";
+import StandardCard, { SelectableCard } from "../../components/StandardCard";
 import { createCard, getCards } from "../../actions/Card";
 import { Button, HStack, Heading, Flex, Box, Grid } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
@@ -24,7 +24,12 @@ export default function ProjectPlanBuilder() {
       selection: false,
     };
   };
-  const UnwrapToCard = (card) => card.cardProps;
+  const UnwrapToCard = (card) => {
+    const cardProps = { ...card.cardProps };
+    cardProps.selected = card.selection;
+    cardProps.setSelection = card.setSelection;
+    return cardProps;
+  };
 
   // Every wrapped card object has an index which can be used to "easily" change
   // state in this component from a <SelectableCard /> child component
@@ -61,15 +66,18 @@ export default function ProjectPlanBuilder() {
   };
 
   // Maps selection objects into renderable cards
-  const SelectionMapper = (card) => {
-    return (
-      <SelectableCard
-        key={card.index}
-        setSelect={SelectionSetter(card.index)}
-        cardProps={card.cardProps}
-        selected={card.selection}
-      />
-    );
+  const RenderSelections = (card) => {
+    const cardProps = { ...card.cardProps };
+    cardProps.selected = card.selection;
+    cardProps.setSelection = SelectionSetter(card.index);
+    return <StandardCard key={card.index} card={cardProps} />;
+  };
+
+  const RenderAsUnselected = (card) => {
+    const cardProps = { ...card.cardProps };
+    cardProps.selected = false;
+    cardProps.setSelection = SelectionSetter(card.index);
+    return <StandardCard key={card.index} card={cardProps} />;
   };
 
   // Filtering logic
@@ -80,8 +88,18 @@ export default function ProjectPlanBuilder() {
   // For PDF exporting
   const [hasLoaded, setHasLoaded] = useState(false);
   useEffect(() => setHasLoaded(true), []);
+  const sampleCard = {
+    images: ["https://picsum.photos/200"],
+    title: "Test sample",
+    comments: [{ body: "bruh", date: new Date() }],
+    tags: ["Bruh"],
+    // selected: true,
+  };
   return (
     <>
+      <Box width="sm">
+        <StandardCard card={sampleCard} />
+      </Box>
       <Flex flexFlow="row nowrap" mb="10">
         <Button opacity="0" cursor="default">
           Bruh
@@ -136,7 +154,7 @@ export default function ProjectPlanBuilder() {
         </Flex>
         {selections.filter((card) => card.selection).length > 0 ? (
           <HStack mt="10" gap="41" flexDirection="row">
-            {selections.filter((card) => card.selection).map(SelectionMapper)}
+            {selections.filter((card) => card.selection).map(RenderSelections)}
           </HStack>
         ) : (
           <Box alignSelf="center" flex="1" width="50%" fontSize="3xl">
@@ -152,7 +170,7 @@ export default function ProjectPlanBuilder() {
         gap="41"
         m="10"
       >
-        {searchedCards.map(WrapToSelection).map(SelectionMapper)}
+        {searchedCards.map(WrapToSelection).map(RenderSelections)}
       </Grid>
     </>
   );

--- a/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
+++ b/src/screens/ProjectPlanBuilder/ProjectPlanBuilder.jsx
@@ -9,11 +9,14 @@ import {
   Box,
   Grid,
   useDisclosure,
+  Input,
 } from "@chakra-ui/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { PDFDownloadLink } from "@react-pdf/renderer";
 import PlanDocumentPDF from "../../components/PlanDocumentPDF/PlanDocumentPDF";
 import { createPlan } from "../../actions/Plan";
+import PlanConfirmationModal from "../../components/Modals/PlanConfirmationModal";
+import { EditIcon, Icon } from "@chakra-ui/icons";
 
 export default function ProjectPlanBuilder() {
   // Primary state in this page is the selections array
@@ -67,7 +70,16 @@ export default function ProjectPlanBuilder() {
   };
 
   // DB action handlers
-  const DeleteHandler = () => undefined;
+  const DiscardPlanHandler = () => {
+    setSelections((prevSelections) => {
+      return prevSelections.map((selection) => {
+        const newSelection = { ...selection };
+        newSelection.selection = false;
+        return newSelection;
+      });
+    });
+    onClose();
+  };
 
   const SavePlanHandler = async () => {
     const selectedCards = selections
@@ -78,6 +90,7 @@ export default function ProjectPlanBuilder() {
     //   name: "Random Plan",
     //   userId: "12345678910",
     // });
+    onClose();
   };
 
   // Search logic
@@ -91,6 +104,8 @@ export default function ProjectPlanBuilder() {
 
   // Confimation modal
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const nameRef = useRef();
+
   return (
     <>
       <Flex flexFlow="row nowrap" mb="10">
@@ -107,7 +122,7 @@ export default function ProjectPlanBuilder() {
         borderRadius={15}
         flexDirection="column"
         flexWrap="none"
-        bgColor="lightgray"
+        bgColor="#DADADA"
         alignItems="flex-start"
         minH="lg"
         overflowX="scroll"
@@ -120,7 +135,18 @@ export default function ProjectPlanBuilder() {
           width="100%"
           alignItems="flex-start"
         >
-          <Heading size="lg">Current Project Plan</Heading>
+          <Box minWidth="40%" as="span">
+            <Input
+              type="text"
+              placeholder="Name your project plan"
+              fontSize="3xl"
+              variant="flushed"
+              pb="3"
+              borderBottomWidth="3px"
+              borderColor="darkgray"
+              ref={nameRef}
+            />
+          </Box>
           <HStack>
             {/* <Button>Download</Button> */}
             {hasLoaded && (
@@ -139,9 +165,8 @@ export default function ProjectPlanBuilder() {
                 )}
               </PDFDownloadLink>
             )}
-            <Button onClick={DeleteHandler}>Delete</Button>
-            <Button onClick={SavePlanHandler} bg="gold" color="white">
-              Save Project Plan
+            <Button onClick={onOpen} bg="gold" color="white">
+              End Project Plan
             </Button>
           </HStack>
         </Flex>
@@ -165,6 +190,12 @@ export default function ProjectPlanBuilder() {
       >
         {searchedCards.map(WrapToSelection).map(RenderCards)}
       </Grid>
+      <PlanConfirmationModal
+        isOpen={isOpen}
+        onClose={onClose}
+        handleSave={SavePlanHandler}
+        handleDiscard={DiscardPlanHandler}
+      />
     </>
   );
 }


### PR DESCRIPTION
# Additional Plan Builder Features

Issue Number(s): #36 

Adds several new features to plan builder:
- A project plan can be discarded and started over with a button
- Project plans save to database with another button
- Card order can be switched before saving
- Save/Discard is handled through modal
- SelectableCard is gone; StandardCard has a few new optional props to handle selection logic
- StandardCard has new UI extensions/options to show selection/order-switching status
- "Add to Plan" in CardModal now mimics "Add to plan" button in card view

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Minor error corrected in `models/Plan.js`
- Changes made to `CardModal.jsx`
- Several changes made to `StandardCard.jsx`
- Heavy changes made to `ProjectPlanBuilder.jsx`
- Possibly unnecessary files: `useTagsFilter.jsx`, `useTextFilter.jsx`, `useUnifiedFilter.jsx`, and `SelectableCard.jsx`

### Related PRs

- #PRNUMBER

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here
