### PR TITLE
Unique URL for Project Plan

### DIFF
--- a/server/mongodb/actions/Plan.ts
+++ b/server/mongodb/actions/Plan.ts
@@ -5,15 +5,8 @@ import { Plan as PlanType } from "src/utils/types";
 
 export async function createPlan(plan: PlanType) {
     await mongoDB();
-    
-    const newPlan = await Plan.create(plan, function (err, docs) {
-        if (err){
-            console.log(err)
-        }
-        else {
-            console.log("Created Plan: ", docs);
-        }
-    });
+
+    const newPlan = await Plan.create(plan);
 
     return newPlan;
 }

--- a/server/mongodb/models/Plan.js
+++ b/server/mongodb/models/Plan.js
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import { Card } from "src/utils/types.ts";
+import { CardSchema } from "server/mongodb/models/Card.js";
 
 const { Schema } = mongoose;
 
@@ -8,7 +8,7 @@ const PlanSchema = new Schema({
     type: String,
   },
   cards: {
-    type: [Card],
+    type: [CardSchema],
   }, 
   name: {
     type: String,

--- a/src/actions/Card.ts
+++ b/src/actions/Card.ts
@@ -4,7 +4,7 @@ import urls from "src/utils/urls";
 import { Card as CardType } from "src/utils/types";
 
 export const getCards = async () => {
-  return fetch(urls.api.card.get, {
+  return fetch(urls.baseUrl + urls.api.card.get, {
     method: "GET",
     mode: "same-origin",
     credentials: "include",
@@ -22,7 +22,7 @@ export const getCards = async () => {
 };
 
 export const getCardById = async (id: string) => {
-  return fetch(urls.api.card.get + id, {
+  return fetch(urls.baseUrl + urls.api.card.get + id, {
     method: "GET",
     mode: "same-origin",
     credentials: "include",
@@ -39,7 +39,7 @@ export const getCardById = async (id: string) => {
 };
 
 export const createCard = async (card: CardType) => {
-  return fetch(urls.api.card.create, {
+  return fetch(urls.baseUrl + urls.api.card.create, {
     method: "POST",
     mode: "same-origin",
     credentials: "include",
@@ -65,7 +65,7 @@ export const updateCardById = async (
   card: Partial<CardType>,
   isOnlyComments?: boolean
 ) => {
-  return fetch(urls.api.card.update, {
+  return fetch(urls.baseUrl + urls.api.card.update, {
     method: "PUT",
     mode: "same-origin",
     credentials: "include",
@@ -91,7 +91,7 @@ export const updateCardById = async (
 };
 
 export const deleteCardById = async (id: string) => {
-  return fetch(urls.api.card.delete, {
+  return fetch(urls.baseUrl + urls.api.card.delete, {
     method: "DELETE",
     mode: "same-origin",
     credentials: "include",

--- a/src/actions/Plan.ts
+++ b/src/actions/Plan.ts
@@ -3,7 +3,7 @@ import urls from "src/utils/urls";
 
 import { Plan as PlanType } from "src/utils/types";
 
-export const getPlans = async (id: string) => {
+export const getPlans = async () => {
   return fetch(urls.baseUrl + urls.api.plan.get, {
     method: "GET",
     mode: "same-origin",

--- a/src/components/PlanDocumentPDF/PlanPDFViewer.jsx
+++ b/src/components/PlanDocumentPDF/PlanPDFViewer.jsx
@@ -1,0 +1,40 @@
+import { Alert, AlertIcon, Heading, VStack } from "@chakra-ui/react";
+import { PDFViewer } from "@react-pdf/renderer";
+import { useEffect, useState } from "react";
+import PlanDocumentPDF from "./PlanDocumentPDF";
+
+const PlanPDFViewer = ({ plan }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (plan) {
+      setLoaded(true);
+    }
+  }, [plan]);
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <VStack style={{ height: "100%" }}>
+      <Heading mb="10px">Viewing Plan: {plan.name}</Heading>
+      {plan.cards.length == 0 ? (
+        <Alert status="error">
+          <AlertIcon />
+          This Project Plan has no cards
+        </Alert>
+      ) : (
+        <PDFViewer
+          style={{ maxWidth: "1000px" }}
+          width={"100%"}
+          height={"100%"}
+        >
+          <PlanDocumentPDF selectedPlanCards={plan.cards} />
+        </PDFViewer>
+      )}
+    </VStack>
+  );
+};
+
+export default PlanPDFViewer;

--- a/src/pages/api/plan/create.ts
+++ b/src/pages/api/plan/create.ts
@@ -7,10 +7,11 @@ import { withSessionRoute } from "src/utils/lib/session";
 // @access  Public
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    await createPlan(req.body);
+    const plan = await createPlan(req.body);
 
     return res.status(200).json({
       success: true,
+      payload: plan,
     });
   } catch (error: any) {
     res.status(400).json({

--- a/src/pages/project-plan/[id].tsx
+++ b/src/pages/project-plan/[id].tsx
@@ -1,0 +1,48 @@
+import { Alert, AlertIcon } from "@chakra-ui/react";
+import dynamic from "next/dynamic";
+import React from "react";
+import { getPlanById } from "src/actions/Plan";
+
+const PlanPDFViewer = dynamic(
+  () => import("../../components/PlanDocumentPDF/PlanPDFViewer"),
+  { ssr: false }
+);
+
+const PDFWrapper = (props: any) => {
+  const { plan, error } = props;
+
+  if (error) {
+    return (
+      <Alert status="error">
+        <AlertIcon />
+        There was an error processing your request
+      </Alert>
+    );
+  }
+
+  return <PlanPDFViewer plan={plan} />;
+};
+
+/**
+ * Errors in getServerSideProps will display the page in 'pages/500.js' (https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props)
+ */
+export async function getServerSideProps(context: any) {
+  const id = context.query.id;
+  try {
+    const plan = await getPlanById(id);
+
+    return {
+      props: {
+        plan: plan[0],
+      },
+    };
+  } catch (e) {
+    return {
+      props: {
+        error: true,
+      },
+    };
+  }
+}
+
+export default PDFWrapper;

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,5 +1,17 @@
+function getBaseURL() {
+  // if backend
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  // if client-side
+  if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+  }
+  return "http://localhost:3000";
+}
+
 export default {
-  baseUrl: process.env.BASE_URL ?? "http://localhost:3000",
+  baseUrl: getBaseURL(),
   pages: {
     index: "/",
     login: "/login",


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #33 

What does this PR change and why?

- project-plan/[id] dynamic route renders the PDF corresponding to a card
- also added an error message for if invalid id passed + an error message if a plan has no cards
- PDF is rendered using React-PDF `<PDFViewer>`
- some additional lint fixes + method updates

## Sample Responses

Plan Found, No Cards: 
![Screen Shot 2022-11-04 at 8 16 45 PM](https://user-images.githubusercontent.com/29695042/200091948-8b846c09-f753-4a6e-b967-b68087732896.png)

Bad ID passed:
![Screen Shot 2022-11-04 at 8 16 28 PM](https://user-images.githubusercontent.com/29695042/200091949-fa6c98cf-8b05-4aab-a4c3-e47864193455.png)

Success:
![Screen Shot 2022-11-04 at 8 16 14 PM](https://user-images.githubusercontent.com/29695042/200091950-5705a2f6-d6f5-4b18-a2b5-4cfc95ba73e4.png)


### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Backend for Plan references CardSchema now
