### PR TITLE
Varshi/image preview

### DIFF
--- a/src/components/Modals/ImagePreviewModal.jsx
+++ b/src/components/Modals/ImagePreviewModal.jsx
@@ -94,20 +94,34 @@ const ImagePreviewModal = ({ isOpen, onClose, cardImages, cardComments }) => {
                 w={6}
                 h={6}
               />
-              <VStack p="2% 5% 2% 2%" alignItems="flex-start" w="35%">
+              <VStack
+                maxH={{ base: "240px", md: "430px", lg: "575px" }}
+                overflow="scroll"
+                p="5% 5% 5% 2%"
+                alignItems="flex-start"
+                w="35%"
+              >
                 {cardComments.map((comment, index) => {
                   return (
-                    <Box key={index}>
-                      <Text>{comment.body}</Text>
+                    <>
+                      <Box w="full" key={index}>
+                        <Text key={index}>{comment.body}</Text>
 
-                      <Flex w="full" justifyContent="space-between">
-                        <Text color="#FFD600">
-                          {new Date(comment.date).toDateString()}
-                        </Text>
-                        <Text color="#0065C1"></Text>
-                      </Flex>
+                        <Flex
+                          key={index}
+                          w="full"
+                          justifyContent="space-between"
+                        >
+                          <Text key={index} color="#FFD600">
+                            {new Date(comment.date).toDateString()}
+                          </Text>
+                          <Text key={index} color="#0065C1">
+                            Edit
+                          </Text>
+                        </Flex>
+                      </Box>
                       <Spacer />
-                    </Box>
+                    </>
                   );
                 })}
               </VStack>

--- a/src/components/Modals/ImagePreviewModal.jsx
+++ b/src/components/Modals/ImagePreviewModal.jsx
@@ -1,0 +1,122 @@
+import React from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+  HStack,
+  Image,
+  VStack,
+  Text,
+  Flex,
+  Spacer,
+  Box,
+} from "@chakra-ui/react";
+
+import { ChevronRightIcon, ChevronLeftIcon } from "@chakra-ui/icons";
+import { useEffect } from "react";
+
+const ImagePreviewModal = ({ isOpen, onClose, cardImages, cardComments }) => {
+  const [currentImageIndex, setCurrentImageIndex] = React.useState(0);
+  const [showBackArrow, setShowBackArrow] = React.useState(false);
+  const [showNextArrow, setShowNextArrow] = React.useState(false);
+
+  useEffect(() => {
+    if (cardImages.length <= 1) {
+      setShowNextArrow(false);
+    } else {
+      setShowNextArrow(true);
+    }
+  }, []);
+
+  function getNextImage() {
+    const nextIndex = currentImageIndex + 1;
+    setShowBackArrow(true);
+    setCurrentImageIndex(nextIndex);
+    if (nextIndex + 1 >= cardImages.length) {
+      setShowNextArrow(false);
+    }
+  }
+
+  function getPreviousImage() {
+    const prevIndex = currentImageIndex - 1;
+    setShowNextArrow(true);
+    setCurrentImageIndex(prevIndex);
+    if (prevIndex - 1 < 0) {
+      setShowBackArrow(false);
+    }
+  }
+
+  return (
+    <>
+      <Modal
+        size={{ base: "sm", md: "2xl", lg: "4xl" }}
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <ModalOverlay />
+        <ModalContent rounded={0}>
+          <ModalCloseButton
+            right="96%"
+            top="3%"
+            outlineColor="white"
+            color="white"
+            zIndex={1}
+            rounded={20}
+            w={{ base: "5px", sm: "10px", md: "15px" }}
+            h={{ base: "5px", sm: "10px", md: "15px" }}
+          />
+          <ModalBody p="0px">
+            <HStack>
+              <Image
+                pos="relative"
+                width="65%"
+                fit="cover"
+                src={cardImages[currentImageIndex]}
+                alt="construction image"
+              />
+
+              <ChevronLeftIcon
+                hidden={!showBackArrow}
+                color="white"
+                pos="absolute"
+                onClick={getPreviousImage}
+                w={6}
+                h={6}
+              />
+              <ChevronRightIcon
+                hidden={!showNextArrow}
+                left="60%"
+                color="white"
+                pos="absolute"
+                onClick={getNextImage}
+                w={6}
+                h={6}
+              />
+              <VStack p="2% 5% 2% 2%" alignItems="flex-start" w="35%">
+                {cardComments.map((comment, index) => {
+                  return (
+                    <Box key={index}>
+                      <Text>{comment.body}</Text>
+
+                      <Flex w="full" justifyContent="space-between">
+                        <Text color="#FFD600">
+                          {new Date(comment.date).toDateString()}
+                        </Text>
+                        <Text color="#0065C1"></Text>
+                      </Flex>
+                      <Spacer />
+                    </Box>
+                  );
+                })}
+              </VStack>
+            </HStack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default ImagePreviewModal;

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -12,11 +12,18 @@ import {
   IconButton,
 } from "@chakra-ui/react";
 import CardModal from "../Modals/CardModal";
+import ImagePreviewModal from "../Modals/ImagePreviewModal";
 import Comments from "../Comments";
 import { CheckIcon, CloseIcon, InfoIcon, RepeatIcon } from "@chakra-ui/icons";
 
 const StandardCard = ({ card, ...props }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isOpenImagePreviewModal,
+    onOpen: onOpenImagePreviewModal,
+    onClose: onCloseImagePreviewModal,
+  } = useDisclosure();
+
   const {
     setSelection = () => undefined,
     mode = "green",
@@ -85,8 +92,16 @@ const StandardCard = ({ card, ...props }) => {
           fit="cover"
           src={card.images[0]}
           alt="construction image"
+          onClick={onOpenImagePreviewModal}
         />
       </Box>
+
+      <ImagePreviewModal
+        isOpen={isOpenImagePreviewModal}
+        onClose={onCloseImagePreviewModal}
+        cardImages={card.images}
+        cardComments={card.comments}
+      />
 
       <Flex p={3} flexDirection="column" flex={1}>
         <Heading size="md">{card.title}</Heading>


### PR DESCRIPTION
## Image Preview Modal
Issue Number(s): #39  

What does this PR change and why?
- When clicking on the image of a standard card, a modal pops up showing the blown up images and comments to the side
- There are previous and next arrows to switch between the picturs
- Note: The close button and arrow buttons are colored white, as shown on Figma, but it can be hard sometimes to see them if the image is lighter in color. 

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

- #PRNUMBER

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here
