### PR TITLE
sd/70-match-standard-card-modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Welcome To The Southface Repo!
+
 ## Useful Links
+
 Make sure you have gone through this walkthrough and all the links down below:
+
 - [Code Tour](/CODETOUR.md)
 - [Engineering Onboarding Guide](https://gtbitsofgood.notion.site/Engineering-Onboarding-Guide-a22683c9388a4b9fb03de442f6664aae)
 - [Figma/Design](https://www.figma.com/file/YTJqtLkjyxYdS3UkfR9dza/Southface-%2F-Fall22?node-id=0%3A1&t=HjMuBBxgKAeaLCzm-1)
+
 ## Stack
 
 - React.js: Front-end

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -128,7 +128,6 @@ const StandardCard = ({ card, setCards, ...props }) => {
             <IconButton
               onClick={onOpen}
               fontSize="lg"
-              isDisabled
               icon={<Icon as={InfoIcon} />}
             ></IconButton>
           </HStack>


### PR DESCRIPTION
## PR Match standard card and modal

Issue Number(s): #70 

This matches the standard card and modal to the components listed above.

### Acceptance Criteria
**Card**
- [ ] Title, photo, general Earthcraft comment (the text below the image; add this text field component), tags, and add to plan button all match the design
- [ ] The Comments component is removed from the Standard Card component (don't delete the file, just don't render it)
- [ ] Title, general comment, and tags wrap around if it does not fit.
- [ ] OnClick of card itself opens the Card Modal component

**Modal**
- [ ] Title, photo, general Earthcraft comment (add this text field component), tags, add to plan and select button all match the design
- [ ] Comments component is removed from the Modal (replaced by general Earthcraft comment)
- [ ] Edit button is kept in the modal. Editing is handled appropriately (this means disconnecting any API calls made for editing comments + adding functionality for editing title)
- [ ] Images have overflow:scroll property. If images don't fit, make sure you are able to scroll. Also, clicking the right, left arrow on the modal shows the next image.
- [ ] EarthcraftComment field is added to the MongoDB Schema and rendered appropriately 


### How to Test

- Test visually on different viewports
- Manual testing for MongoDB
