### PR TITLE
hc/98-admin-edit-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@react-pdf/renderer": "^3.0.0",
     "bcryptjs": "^2.4.3",
     "chakra-ui-file-picker": "^0.3.0",
+    "final-form": "^4.20.9",
     "focus-visible": "^5.2.0",
     "formik": "^2.2.9",
     "framer-motion": "^6",
@@ -66,6 +67,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-final-form": "^6.5.9",
     "react-icons": "^4.7.1",
     "react-rating-stars-component": "^2.2.0",
     "swr": "^2.0.3"

--- a/src/components/FormComponents/CheckboxArrayControl.jsx
+++ b/src/components/FormComponents/CheckboxArrayControl.jsx
@@ -1,0 +1,24 @@
+import { Checkbox } from "@chakra-ui/react";
+import { useField } from "react-final-form";
+
+const CheckboxArrayControl = ({ name, value, children }) => {
+  const {
+    input: { checked, ...input },
+    meta: { error, touched },
+  } = useField(name, {
+    type: "checkbox",
+    value,
+  });
+  return (
+    <Checkbox
+      {...input}
+      isChecked={checked}
+      isInvalid={error && touched}
+      color="#6D6E70"
+    >
+      {children}
+    </Checkbox>
+  );
+};
+
+export default CheckboxArrayControl;

--- a/src/components/FormComponents/Control.jsx
+++ b/src/components/FormComponents/Control.jsx
@@ -1,0 +1,11 @@
+import { FormControl } from "@chakra-ui/react";
+import { useField } from "react-final-form";
+
+const Control = ({ name, ...rest }) => {
+  const {
+    meta: { error, touched },
+  } = useField(name, { subscription: { touched: true, error: true } });
+  return <FormControl m={0} {...rest} isInvalid={error && touched} />;
+};
+
+export default Control;

--- a/src/components/FormComponents/Error.jsx
+++ b/src/components/FormComponents/Error.jsx
@@ -1,0 +1,11 @@
+import { FormErrorMessage } from "@chakra-ui/react";
+import { useField } from "react-final-form";
+
+const Error = ({ name }) => {
+  const {
+    meta: { error },
+  } = useField(name, { subscription: { error: true } });
+  return <FormErrorMessage>{error}</FormErrorMessage>;
+};
+
+export default Error;

--- a/src/components/FormComponents/InputControl.jsx
+++ b/src/components/FormComponents/InputControl.jsx
@@ -1,0 +1,27 @@
+import { FormLabel, HStack, Input } from "@chakra-ui/react";
+import { useField } from "react-final-form";
+import Control from "./Control";
+import Error from "./Error";
+
+const InputControl = ({ name, label, type, ...props }) => {
+  const { input, meta } = useField(name);
+  return (
+    <Control name={name}>
+      <HStack>
+        <FormLabel htmlFor={name} m={0} color="#6D6E70">
+          {label}
+        </FormLabel>
+        <Error name={name} />
+      </HStack>
+      <Input
+        {...props}
+        {...input}
+        isInvalid={meta.error && meta.touched}
+        id={name}
+        type={type}
+      />
+    </Control>
+  );
+};
+
+export default InputControl;

--- a/src/components/FormComponents/Multiselect.jsx
+++ b/src/components/FormComponents/Multiselect.jsx
@@ -1,0 +1,33 @@
+import { FormLabel, HStack, Stack } from "@chakra-ui/react";
+import CheckboxArrayControl from "./CheckboxArrayControl";
+import Control from "./Control";
+import Error from "./Error";
+
+const Multiselect = ({ name, label, entries }) => {
+  return (
+    <Control name={name} my={4}>
+      <HStack>
+        <FormLabel
+          htmlFor={name}
+          m={0}
+          fontSize="xl"
+          fontWeight="bold"
+          color="#8C8C8C"
+        >
+          {label}
+        </FormLabel>
+        <Error name={name} />
+      </HStack>
+
+      <Stack mt={1} spacing={1}>
+        {entries.map((e, index) => (
+          <CheckboxArrayControl key={index} name={name} value={e}>
+            {e}
+          </CheckboxArrayControl>
+        ))}
+      </Stack>
+    </Control>
+  );
+};
+
+export default Multiselect;

--- a/src/components/FormComponents/TextareaControl.jsx
+++ b/src/components/FormComponents/TextareaControl.jsx
@@ -1,0 +1,22 @@
+import { FormLabel, HStack, Textarea } from "@chakra-ui/react";
+import { Field } from "react-final-form";
+import Control from "./Control";
+import Error from "./Error";
+
+const AdaptedTextarea = ({ input, meta, ...rest }) => (
+  <Textarea {...input} {...rest} isInvalid={meta.error && meta.touched} />
+);
+
+const TextareaControl = ({ name, label, ...props }) => (
+  <Control name={name}>
+    <HStack>
+      <FormLabel htmlFor={name} m={0} color="#6D6E70">
+        {label}
+      </FormLabel>
+      <Error name={name} />
+    </HStack>
+    <Field name={name} component={AdaptedTextarea} id={name} {...props} />
+  </Control>
+);
+
+export default TextareaControl;

--- a/src/components/Modals/CardModal/AddImageModal.jsx
+++ b/src/components/Modals/CardModal/AddImageModal.jsx
@@ -1,7 +1,13 @@
 import { AddIcon } from "@chakra-ui/icons";
-import { Box, Button } from "@chakra-ui/react";
+import { Box, Button, useDisclosure } from "@chakra-ui/react";
 
 const AddImageModal = ({ ...props }) => {
+  const {
+    // isOpen: isImageOpen,
+    onOpen: onImageOpen,
+    // onClose: onImageClose,
+  } = useDisclosure();
+
   return (
     <>
       <Box position="relative" {...props} width="full" height="full">
@@ -14,6 +20,7 @@ const AddImageModal = ({ ...props }) => {
             height="calc(100% - .5rem)"
             bgColor="white"
             _hover={{ bgColor: "#ededed" }}
+            onClick={onImageOpen}
           >
             <Box padding="1.5rem" rounded="full" bgColor="#6D6E70">
               <AddIcon boxSize="2.5rem" color="white" />
@@ -21,6 +28,7 @@ const AddImageModal = ({ ...props }) => {
           </Button>
         </Box>
       </Box>
+      {/* <ModifyImageModal isOpen={isImageOpen} onClose={onImageClose} /> */}
     </>
   );
 };

--- a/src/components/Modals/CardModal/AddImageModal.jsx
+++ b/src/components/Modals/CardModal/AddImageModal.jsx
@@ -1,16 +1,68 @@
 import { AddIcon } from "@chakra-ui/icons";
-import { Box, Button, useDisclosure } from "@chakra-ui/react";
+import { Box, Button, Input, Spinner, useToast } from "@chakra-ui/react";
+import { useRef } from "react";
+import { isValidBlobUrl, uploadFile } from "src/lib/utils/blobStorage";
 
-const AddImageModal = ({ ...props }) => {
-  const {
-    // isOpen: isImageOpen,
-    onOpen: onImageOpen,
-    // onClose: onImageClose,
-  } = useDisclosure();
+const AddImageModal = ({ setValue, form, cardId, ...props }) => {
+  const fileRef = useRef();
+  const toastRef = useRef();
+  const uploadingToast = useToast();
+
+  const handleImageUploads = (images) => {
+    toastRef.current = uploadingToast({
+      title: images.length == 1 ? "Uploading Image..." : "Uploading Images...",
+      status: "info",
+      duration: 20000,
+      isClosable: false,
+      icon: <Spinner />,
+    });
+    const existingImages = JSON.parse(JSON.stringify(form.values.images));
+    const metadata = {};
+    const tags = {
+      cardId: cardId,
+    };
+
+    for (let image of images) {
+      let imagesSucceeded = 0;
+      uploadFile(image.name, image, metadata, tags).then((res) => {
+        console.log(res);
+        if (!(res instanceof Error) && isValidBlobUrl(res)) {
+          imagesSucceeded++;
+          existingImages.push(res);
+          if (imagesSucceeded == images.length) {
+            if (toastRef.current) {
+              uploadingToast.update(toastRef.current, {
+                title: "Image Uploaded",
+                duration: 2000,
+                isClosable: true,
+                status: "success",
+              });
+            }
+            setValue("images", existingImages);
+          }
+        } else {
+          if (toastRef.current) {
+            uploadingToast.update(toastRef.current, {
+              title: "Upload Failed",
+              duration: 10000,
+              isClosable: true,
+              status: "error",
+            });
+          }
+        }
+      });
+    }
+  };
 
   return (
     <>
-      <Box position="relative" {...props} width="full" height="full">
+      <Box
+        position="relative"
+        {...props}
+        width="full"
+        height="full"
+        minHeight="48"
+      >
         <Box width="full" height="full">
           <Button
             justifyContent="center"
@@ -20,15 +72,29 @@ const AddImageModal = ({ ...props }) => {
             height="calc(100% - .5rem)"
             bgColor="white"
             _hover={{ bgColor: "#ededed" }}
-            onClick={onImageOpen}
+            onClick={() => {
+              fileRef.current.click();
+              fileRef.current.value = null;
+            }}
           >
             <Box padding="1.5rem" rounded="full" bgColor="#6D6E70">
               <AddIcon boxSize="2.5rem" color="white" />
+              <Input
+                type="file"
+                id="fileInput"
+                ref={fileRef}
+                display="none"
+                accept="image/png,image/jpg,image/jpeg,image/gif,image/webp,image/tiff"
+                multiple={true}
+                onChange={(e) => {
+                  let files = e.target.files;
+                  handleImageUploads(files);
+                }}
+              />
             </Box>
           </Button>
         </Box>
       </Box>
-      {/* <ModifyImageModal isOpen={isImageOpen} onClose={onImageClose} /> */}
     </>
   );
 };

--- a/src/components/Modals/CardModal/AddImageModal.jsx
+++ b/src/components/Modals/CardModal/AddImageModal.jsx
@@ -1,0 +1,28 @@
+import { AddIcon } from "@chakra-ui/icons";
+import { Box, Button } from "@chakra-ui/react";
+
+const AddImageModal = ({ ...props }) => {
+  return (
+    <>
+      <Box position="relative" {...props} width="full" height="full">
+        <Box width="full" height="full">
+          <Button
+            justifyContent="center"
+            alignItems="center"
+            boxShadow="lg"
+            width="full"
+            height="calc(100% - .5rem)"
+            bgColor="white"
+            _hover={{ bgColor: "#ededed" }}
+          >
+            <Box padding="1.5rem" rounded="full" bgColor="#6D6E70">
+              <AddIcon boxSize="2.5rem" color="white" />
+            </Box>
+          </Button>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default AddImageModal;

--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -1,8 +1,11 @@
+import { ArrowUpIcon, CloseIcon } from "@chakra-ui/icons";
 import {
+  Box,
   Button,
   Flex,
   Heading,
   HStack,
+  Input,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -14,10 +17,15 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
+import { useState } from "react";
+import { Form } from "react-final-form";
+import useUser from "../../../lib/hooks/useUser";
 import ArrowIcon from "../../Carousel/ArrowIcon";
 import Carousel from "../../Carousel/Carousel";
 import ImagePreviewModal from "../ImagePreviewModal";
 import ModalImage from "../ModalImage";
+import cardEditValidator from "./cardEditValidator";
+import ConfirmActionsModal from "./ConfirmActionModal";
 
 const CardModal = ({
   card,
@@ -32,9 +40,51 @@ const CardModal = ({
     onClose: onCloseImagePreviewModal,
   } = useDisclosure();
 
+  const {
+    isOpen: isDiscardChangesOpen,
+    onOpen: onDiscardChangesOpen,
+    onClose: onDiscardChangesClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isSaveChangesOpen,
+    onOpen: onSaveChangesOpen,
+    onClose: onSaveChangesClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isDeleteStandardOpen,
+    onOpen: onDeleteStandardOpen,
+    onClose: onDeleteStandardClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isImageDeleteOpen,
+    onOpen: onImageDeleteOpen,
+    onClose: onImageDeleteClose,
+  } = useDisclosure();
+
+  const [editing, setEditing] = useState(false);
+  const { user } = useUser();
+
   const openImagePreviewCallback = () => {
     onCloseCardModal();
     onOpenImagePreviewModal();
+  };
+
+  const editSubmit = async () => {};
+
+  const discardChanges = () => {
+    setEditing(false);
+    onDiscardChangesClose();
+  };
+
+  const saveChanges = () => {
+    onSaveChangesClose();
+  };
+
+  const deleteStandard = () => {
+    onDeleteStandardClose();
   };
 
   return (
@@ -45,90 +95,257 @@ const CardModal = ({
         onClose={onCloseCardModal}
         size={{ base: "xs", md: "2xl", lg: "4xl" }}
       >
-        <ModalOverlay />
-        <ModalContent rounded={14}>
-          <ModalCloseButton right={2} top={0} m={4} />
-          <ModalHeader mt={10} mx={6}>
-            <Flex justifyContent="space-between">
-              <Heading mb={2}>{card.title}</Heading>
-            </Flex>
-          </ModalHeader>
+        <Form
+          onSubmit={editSubmit}
+          validate={cardEditValidator}
+          render={() => {
+            return (
+              <>
+                <ModalOverlay />
+                <ModalContent rounded={14}>
+                  <ModalCloseButton right={2} top={0} m={4} />
+                  <ModalHeader mt={10} mx={6}>
+                    <Flex justifyContent="space-between">
+                      <Heading mb={2}>{card.title}</Heading>
+                      {user.isAdmin ? (
+                        !editing ? (
+                          <Button
+                            bgColor="black"
+                            size="sm"
+                            p="1em"
+                            rounded="3xl"
+                            color="#ffffff"
+                            border="solid 2px #ffffff"
+                            width="auto"
+                            _hover={{ border: "solid 2px #6d6e70" }}
+                            onClick={() => {
+                              setEditing(true);
+                            }}
+                          >
+                            Edit
+                          </Button>
+                        ) : (
+                          <Flex gap={2} justifyContent="right">
+                            <Button
+                              bgColor="white"
+                              rounded="3xl"
+                              size="sm"
+                              color="#6d6e70"
+                              border="solid 1px #6d6e70"
+                              width="auto"
+                              onClick={onDiscardChangesOpen}
+                            >
+                              Discard Changes
+                            </Button>
+                            <Button
+                              bgColor="#00ACC8"
+                              rounded="3xl"
+                              size="sm"
+                              color="white"
+                              width="auto"
+                              _hover={{ bgColor: "#0690a7" }}
+                              _active={{ bgColor: "#057b8f" }}
+                              onClick={onSaveChangesOpen}
+                            >
+                              Save Changes
+                            </Button>
+                          </Flex>
+                        )
+                      ) : (
+                        <></>
+                      )}
+                    </Flex>
+                  </ModalHeader>
 
-          <ModalBody mx={6}>
-            <Flex flexDirection="column">
-              <Carousel
-                cols={3}
-                rows={1}
-                gap={10}
-                containerStyle={{
-                  marginBottom: "1.5rem",
-                }}
-                arrowLeft={<ArrowIcon orientation="left" />}
-                arrowRight={<ArrowIcon orientation="right" />}
-              >
-                {card.images.map(({ imageUrl: image }, index) => (
-                  <Carousel.Item key={index}>
-                    <ModalImage
-                      image={image}
-                      openImagePreviewCallback={openImagePreviewCallback}
-                    />
-                  </Carousel.Item>
-                ))}
-              </Carousel>
+                  <ModalBody mx={6}>
+                    <Flex flexDirection="column">
+                      <Carousel
+                        cols={3}
+                        rows={1}
+                        gap={10}
+                        containerStyle={{
+                          marginBottom: "1.5rem",
+                        }}
+                        arrowLeft={<ArrowIcon orientation="left" />}
+                        arrowRight={<ArrowIcon orientation="right" />}
+                      >
+                        {card.images.map(({ imageUrl: image }, index) => (
+                          <Carousel.Item key={index}>
+                            <ModalImage
+                              editing={editing}
+                              image={image}
+                              openImagePreviewCallback={
+                                openImagePreviewCallback
+                              }
+                              onImageDeleteOpen={onImageDeleteOpen}
+                              isImageDeleteOpen={isImageDeleteOpen}
+                              onImageDeleteClose={onImageDeleteClose}
+                            />
+                          </Carousel.Item>
+                        ))}
+                      </Carousel>
 
-              <Text lineHeight="normal" fontSize="18px">
-                {card.criteria}
-              </Text>
+                      <Text lineHeight="normal" fontSize="18px">
+                        {card.criteria}
+                      </Text>
 
-              <SimpleGrid mt={3} mb={15} columns={2}>
-                <HStack gap={1} overflowX="auto">
-                  {card.tags.map((tag, index) => (
-                    <Tag
-                      bgColor="#c4d600"
-                      borderRadius="30px"
-                      key={index}
-                      minWidth="fill"
-                    >
-                      {tag}
-                    </Tag>
-                  ))}
-                </HStack>
-                <Flex gap={2} justifyContent="right">
-                  <Button
-                    bgColor="white"
-                    size="lg"
-                    rounded={16}
-                    color="#6d6e70"
-                    border="solid 1px #6d6e70"
-                    fontSize="22px"
-                    width="auto"
-                    onClick={openImagePreviewCallback}
-                  >
-                    View Notes
-                  </Button>
-                  <Button
-                    bgColor="#00ACC8"
-                    size="lg"
-                    rounded={16}
-                    color="white"
-                    fontSize="22px"
-                    width="auto"
-                    _hover={{ bgColor: "#0690a7" }}
-                    _active={{ bgColor: "#057b8f" }}
-                  >
-                    Add to Report
-                  </Button>
-                </Flex>
-              </SimpleGrid>
-            </Flex>
-          </ModalBody>
-        </ModalContent>
+                      <SimpleGrid
+                        mt={3}
+                        mb={15}
+                        columns={2}
+                        gap="1rem"
+                        alignItems="end"
+                      >
+                        <Flex flexDirection="column" gap="1rem">
+                          <HStack gap={1} overflowX="auto">
+                            {card.tags.map((tag, index) => (
+                              <Box key={index} position="relative">
+                                <Tag
+                                  bgColor="#c4d600"
+                                  borderRadius="30px"
+                                  minWidth="fill"
+                                  mt={editing ? "0.6rem" : "0rem"}
+                                  fontSize="1rem"
+                                  px="1rem"
+                                >
+                                  {tag}
+                                </Tag>
+                                {editing ? (
+                                  <Button
+                                    position="absolute"
+                                    top="0.2rem"
+                                    right="-0.5rem"
+                                    backgroundColor="#FFFFFF"
+                                    color="#6D6E70"
+                                    boxShadow="0 0 0.5rem #b3b3b3"
+                                    size="xl"
+                                    height="max"
+                                    rounded="full"
+                                    p="0.3rem"
+                                  >
+                                    <CloseIcon h={1.5} w={1.5} />
+                                  </Button>
+                                ) : (
+                                  <></>
+                                )}
+                              </Box>
+                            ))}
+                          </HStack>
+                          {editing ? (
+                            <Flex
+                              border="solid 1px #B4B4B4B4"
+                              rounded="xl"
+                              alignItems="center"
+                            >
+                              <Input
+                                placeholder="Add a Tag"
+                                rounded="2xl"
+                                border="none"
+                                focusBorderColor="transparent"
+                                width="full"
+                              />
+                              <Button
+                                bgColor="transparent"
+                                rounded="full"
+                                width="max"
+                                height="max"
+                                p="0.2rem"
+                                mr="1rem"
+                                my="0.8rem"
+                                size="xl"
+                                border="solid 2px black"
+                                _hover={{ bgColor: "#f0f0f0" }}
+                              >
+                                <ArrowUpIcon h={4} w={4} color="black" />
+                              </Button>
+                            </Flex>
+                          ) : (
+                            <></>
+                          )}
+                        </Flex>
+                        <Flex gap={2} justifyContent="right">
+                          {editing ? (
+                            <Button
+                              bgColor="#B90000"
+                              rounded="3xl"
+                              size="sm"
+                              color="#FFFFFF"
+                              border="solid 2px #FFFFFF"
+                              width="auto"
+                              _hover={{ border: "solid 2px #B90000" }}
+                              _active={{ bgColor: "#B90000" }}
+                              onClick={onDeleteStandardOpen}
+                            >
+                              Delete Standard
+                            </Button>
+                          ) : (
+                            <>
+                              <Button
+                                bgColor="white"
+                                rounded="3xl"
+                                size="sm"
+                                color="#6d6e70"
+                                border="solid 1px #6d6e70"
+                                width="auto"
+                                onClick={openImagePreviewCallback}
+                              >
+                                View Notes
+                              </Button>
+                              <Button
+                                bgColor="#00ACC8"
+                                rounded="3xl"
+                                size="sm"
+                                color="white"
+                                width="auto"
+                                _hover={{ bgColor: "#0690a7" }}
+                                _active={{ bgColor: "#057b8f" }}
+                              >
+                                Add to Report
+                              </Button>
+                            </>
+                          )}
+                        </Flex>
+                      </SimpleGrid>
+                    </Flex>
+                  </ModalBody>
+                </ModalContent>
+              </>
+            );
+          }}
+        />
       </Modal>
       <ImagePreviewModal
         isOpen={isOpenImagePreviewModal}
         onClose={onCloseImagePreviewModal}
         card={card}
         setCards={setCards}
+      />
+      <ConfirmActionsModal
+        isOpen={isDiscardChangesOpen}
+        onClose={onDiscardChangesClose}
+        handleDiscardChanges={discardChanges}
+        prompt="Are you sure you want to discard all changes?"
+        subcontent="All progress will be lost."
+        abandonActionText="Yes, discard changes"
+        confirmActionText="No, return to edit"
+      />
+      <ConfirmActionsModal
+        isOpen={isSaveChangesOpen}
+        onClose={onSaveChangesClose}
+        handleDiscardChanges={saveChanges}
+        prompt="Are you sure you want to save all changes?"
+        abandonActionText="Yes, save changes"
+        confirmActionText="No, return to edit"
+      />
+      <ConfirmActionsModal
+        isOpen={isDeleteStandardOpen}
+        onClose={onDeleteStandardClose}
+        handleDiscardChanges={deleteStandard}
+        prompt={`Are you sure you want to delete ${card.title}?`}
+        subcontent="You will be unable to recover it after it has been deleted."
+        abandonActionText="Yes, delete standard"
+        confirmActionText="No, return to edit"
+        colorScheme="red"
       />
     </>
   );

--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -1,17 +1,45 @@
-import { Modal } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { Form } from "react-final-form";
+import { deleteCardById, updateCardById } from "../../../actions/Card";
 import cardEditValidator from "./cardEditValidator";
 import CardModalFormContent from "./CardModalFormContent";
 
 const CardModal = ({
   card,
+  cards,
   isOpenCardModal,
   onCloseCardModal,
   setCards,
   ...rest
 }) => {
-  const editSubmit = async () => {};
+  const editSubmit = async (values) => {
+    const dirtyFields = Object.keys(values).filter((key) => {
+      return values[key] !== initialCard[key] && key !== "newTag";
+    });
+    const dirtyValues = dirtyFields.reduce((obj, key) => {
+      obj[key] = values[key];
+      return obj;
+    }, {});
+    let newCard = await updateCardById(card._id, dirtyValues);
+    let newCards = JSON.parse(JSON.stringify(cards));
+    for (let oldCardIndex in newCards) {
+      if (newCards[oldCardIndex]._id === card._id) {
+        newCards[oldCardIndex] = newCard;
+      }
+    }
+    setCards(newCards);
+  };
+
+  const handleDeleteStandard = async () => {
+    await deleteCardById(card._id);
+    let newCards = [];
+    for (let oldCardIndex in cards) {
+      if (cards[oldCardIndex]._id !== card._id) {
+        newCards[oldCardIndex] = cards[oldCardIndex];
+      }
+    }
+    setCards(newCards);
+  };
 
   const [initialCard, setInitialCard] = useState();
   useEffect(() => {
@@ -20,37 +48,43 @@ const CardModal = ({
 
   return (
     <>
-      <Modal
-        {...rest}
-        isOpen={isOpenCardModal}
-        onClose={onCloseCardModal}
-        size={{ base: "xs", md: "2xl", lg: "4xl" }}
-      >
-        <Form
-          onSubmit={editSubmit}
-          validate={cardEditValidator}
-          initialValues={initialCard}
-          mutators={{
-            setValue: ([field, value], state, { changeValue }) => {
-              changeValue(state, field, () => value);
-            },
-          }}
-          render={({
-            form: {
-              mutators: { setValue },
-            },
-          }) => {
-            return (
-              <CardModalFormContent
-                card={card}
-                setCards={setCards}
-                onCloseCardModal={onCloseCardModal}
-                setValue={setValue}
-              />
-            );
-          }}
-        />
-      </Modal>
+      <Form
+        onSubmit={editSubmit}
+        validate={cardEditValidator}
+        initialValues={initialCard}
+        mutators={{
+          setValue: ([field, value], state, { changeValue }) => {
+            changeValue(state, field, () => value);
+            const fieldState = state.fields[field];
+            if (fieldState) {
+              fieldState.touched = true;
+              fieldState.modified = true;
+            }
+          },
+        }}
+        render={({
+          form: {
+            mutators: { setValue },
+          },
+          form,
+          handleSubmit,
+        }) => {
+          return (
+            <CardModalFormContent
+              card={card}
+              setCards={setCards}
+              onCloseCardModal={onCloseCardModal}
+              setValue={setValue}
+              reset={form.reset}
+              handleSubmit={handleSubmit}
+              registerField={form.registerField}
+              isOpenCardModal={isOpenCardModal}
+              rest={rest}
+              handleDeleteStandard={handleDeleteStandard}
+            />
+          );
+        }}
+      />
     </>
   );
 };

--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -1,31 +1,8 @@
-import { ArrowUpIcon, CloseIcon } from "@chakra-ui/icons";
-import {
-  Box,
-  Button,
-  Flex,
-  Heading,
-  HStack,
-  Input,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
-  SimpleGrid,
-  Tag,
-  Text,
-  useDisclosure,
-} from "@chakra-ui/react";
-import { useState } from "react";
+import { Modal } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import { Form } from "react-final-form";
-import useUser from "../../../lib/hooks/useUser";
-import ArrowIcon from "../../Carousel/ArrowIcon";
-import Carousel from "../../Carousel/Carousel";
-import ImagePreviewModal from "../ImagePreviewModal";
-import ModalImage from "../ModalImage";
 import cardEditValidator from "./cardEditValidator";
-import ConfirmActionsModal from "./ConfirmActionModal";
+import CardModalFormContent from "./CardModalFormContent";
 
 const CardModal = ({
   card,
@@ -34,58 +11,12 @@ const CardModal = ({
   setCards,
   ...rest
 }) => {
-  const {
-    isOpen: isOpenImagePreviewModal,
-    onOpen: onOpenImagePreviewModal,
-    onClose: onCloseImagePreviewModal,
-  } = useDisclosure();
-
-  const {
-    isOpen: isDiscardChangesOpen,
-    onOpen: onDiscardChangesOpen,
-    onClose: onDiscardChangesClose,
-  } = useDisclosure();
-
-  const {
-    isOpen: isSaveChangesOpen,
-    onOpen: onSaveChangesOpen,
-    onClose: onSaveChangesClose,
-  } = useDisclosure();
-
-  const {
-    isOpen: isDeleteStandardOpen,
-    onOpen: onDeleteStandardOpen,
-    onClose: onDeleteStandardClose,
-  } = useDisclosure();
-
-  const {
-    isOpen: isImageDeleteOpen,
-    onOpen: onImageDeleteOpen,
-    onClose: onImageDeleteClose,
-  } = useDisclosure();
-
-  const [editing, setEditing] = useState(false);
-  const { user } = useUser();
-
-  const openImagePreviewCallback = () => {
-    onCloseCardModal();
-    onOpenImagePreviewModal();
-  };
-
   const editSubmit = async () => {};
 
-  const discardChanges = () => {
-    setEditing(false);
-    onDiscardChangesClose();
-  };
-
-  const saveChanges = () => {
-    onSaveChangesClose();
-  };
-
-  const deleteStandard = () => {
-    onDeleteStandardClose();
-  };
+  const [initialCard, setInitialCard] = useState();
+  useEffect(() => {
+    setInitialCard(JSON.parse(JSON.stringify(card)));
+  }, [card]);
 
   return (
     <>
@@ -98,255 +29,28 @@ const CardModal = ({
         <Form
           onSubmit={editSubmit}
           validate={cardEditValidator}
-          render={() => {
+          initialValues={initialCard}
+          mutators={{
+            setValue: ([field, value], state, { changeValue }) => {
+              changeValue(state, field, () => value);
+            },
+          }}
+          render={({
+            form: {
+              mutators: { setValue },
+            },
+          }) => {
             return (
-              <>
-                <ModalOverlay />
-                <ModalContent rounded={14}>
-                  <ModalCloseButton right={2} top={0} m={4} />
-                  <ModalHeader mt={10} mx={6}>
-                    <Flex justifyContent="space-between">
-                      <Heading mb={2}>{card.title}</Heading>
-                      {user.isAdmin ? (
-                        !editing ? (
-                          <Button
-                            bgColor="black"
-                            size="sm"
-                            p="1em"
-                            rounded="3xl"
-                            color="#ffffff"
-                            border="solid 2px #ffffff"
-                            width="auto"
-                            _hover={{ border: "solid 2px #6d6e70" }}
-                            onClick={() => {
-                              setEditing(true);
-                            }}
-                          >
-                            Edit
-                          </Button>
-                        ) : (
-                          <Flex gap={2} justifyContent="right">
-                            <Button
-                              bgColor="white"
-                              rounded="3xl"
-                              size="sm"
-                              color="#6d6e70"
-                              border="solid 1px #6d6e70"
-                              width="auto"
-                              onClick={onDiscardChangesOpen}
-                            >
-                              Discard Changes
-                            </Button>
-                            <Button
-                              bgColor="#00ACC8"
-                              rounded="3xl"
-                              size="sm"
-                              color="white"
-                              width="auto"
-                              _hover={{ bgColor: "#0690a7" }}
-                              _active={{ bgColor: "#057b8f" }}
-                              onClick={onSaveChangesOpen}
-                            >
-                              Save Changes
-                            </Button>
-                          </Flex>
-                        )
-                      ) : (
-                        <></>
-                      )}
-                    </Flex>
-                  </ModalHeader>
-
-                  <ModalBody mx={6}>
-                    <Flex flexDirection="column">
-                      <Carousel
-                        cols={3}
-                        rows={1}
-                        gap={10}
-                        containerStyle={{
-                          marginBottom: "1.5rem",
-                        }}
-                        arrowLeft={<ArrowIcon orientation="left" />}
-                        arrowRight={<ArrowIcon orientation="right" />}
-                      >
-                        {card.images.map(({ imageUrl: image }, index) => (
-                          <Carousel.Item key={index}>
-                            <ModalImage
-                              editing={editing}
-                              image={image}
-                              openImagePreviewCallback={
-                                openImagePreviewCallback
-                              }
-                              onImageDeleteOpen={onImageDeleteOpen}
-                              isImageDeleteOpen={isImageDeleteOpen}
-                              onImageDeleteClose={onImageDeleteClose}
-                            />
-                          </Carousel.Item>
-                        ))}
-                      </Carousel>
-
-                      <Text lineHeight="normal" fontSize="18px">
-                        {card.criteria}
-                      </Text>
-
-                      <SimpleGrid
-                        mt={3}
-                        mb={15}
-                        columns={2}
-                        gap="1rem"
-                        alignItems="end"
-                      >
-                        <Flex flexDirection="column" gap="1rem">
-                          <HStack gap={1} overflowX="auto">
-                            {card.tags.map((tag, index) => (
-                              <Box key={index} position="relative">
-                                <Tag
-                                  bgColor="#c4d600"
-                                  borderRadius="30px"
-                                  minWidth="fill"
-                                  mt={editing ? "0.6rem" : "0rem"}
-                                  fontSize="1rem"
-                                  px="1rem"
-                                >
-                                  {tag}
-                                </Tag>
-                                {editing ? (
-                                  <Button
-                                    position="absolute"
-                                    top="0.2rem"
-                                    right="-0.5rem"
-                                    backgroundColor="#FFFFFF"
-                                    color="#6D6E70"
-                                    boxShadow="0 0 0.5rem #b3b3b3"
-                                    size="xl"
-                                    height="max"
-                                    rounded="full"
-                                    p="0.3rem"
-                                  >
-                                    <CloseIcon h={1.5} w={1.5} />
-                                  </Button>
-                                ) : (
-                                  <></>
-                                )}
-                              </Box>
-                            ))}
-                          </HStack>
-                          {editing ? (
-                            <Flex
-                              border="solid 1px #B4B4B4B4"
-                              rounded="xl"
-                              alignItems="center"
-                            >
-                              <Input
-                                placeholder="Add a Tag"
-                                rounded="2xl"
-                                border="none"
-                                focusBorderColor="transparent"
-                                width="full"
-                              />
-                              <Button
-                                bgColor="transparent"
-                                rounded="full"
-                                width="max"
-                                height="max"
-                                p="0.2rem"
-                                mr="1rem"
-                                my="0.8rem"
-                                size="xl"
-                                border="solid 2px black"
-                                _hover={{ bgColor: "#f0f0f0" }}
-                              >
-                                <ArrowUpIcon h={4} w={4} color="black" />
-                              </Button>
-                            </Flex>
-                          ) : (
-                            <></>
-                          )}
-                        </Flex>
-                        <Flex gap={2} justifyContent="right">
-                          {editing ? (
-                            <Button
-                              bgColor="#B90000"
-                              rounded="3xl"
-                              size="sm"
-                              color="#FFFFFF"
-                              border="solid 2px #FFFFFF"
-                              width="auto"
-                              _hover={{ border: "solid 2px #B90000" }}
-                              _active={{ bgColor: "#B90000" }}
-                              onClick={onDeleteStandardOpen}
-                            >
-                              Delete Standard
-                            </Button>
-                          ) : (
-                            <>
-                              <Button
-                                bgColor="white"
-                                rounded="3xl"
-                                size="sm"
-                                color="#6d6e70"
-                                border="solid 1px #6d6e70"
-                                width="auto"
-                                onClick={openImagePreviewCallback}
-                              >
-                                View Notes
-                              </Button>
-                              <Button
-                                bgColor="#00ACC8"
-                                rounded="3xl"
-                                size="sm"
-                                color="white"
-                                width="auto"
-                                _hover={{ bgColor: "#0690a7" }}
-                                _active={{ bgColor: "#057b8f" }}
-                              >
-                                Add to Report
-                              </Button>
-                            </>
-                          )}
-                        </Flex>
-                      </SimpleGrid>
-                    </Flex>
-                  </ModalBody>
-                </ModalContent>
-              </>
+              <CardModalFormContent
+                card={card}
+                setCards={setCards}
+                onCloseCardModal={onCloseCardModal}
+                setValue={setValue}
+              />
             );
           }}
         />
       </Modal>
-      <ImagePreviewModal
-        isOpen={isOpenImagePreviewModal}
-        onClose={onCloseImagePreviewModal}
-        card={card}
-        setCards={setCards}
-      />
-      <ConfirmActionsModal
-        isOpen={isDiscardChangesOpen}
-        onClose={onDiscardChangesClose}
-        handleDiscardChanges={discardChanges}
-        prompt="Are you sure you want to discard all changes?"
-        subcontent="All progress will be lost."
-        abandonActionText="Yes, discard changes"
-        confirmActionText="No, return to edit"
-      />
-      <ConfirmActionsModal
-        isOpen={isSaveChangesOpen}
-        onClose={onSaveChangesClose}
-        handleDiscardChanges={saveChanges}
-        prompt="Are you sure you want to save all changes?"
-        abandonActionText="Yes, save changes"
-        confirmActionText="No, return to edit"
-      />
-      <ConfirmActionsModal
-        isOpen={isDeleteStandardOpen}
-        onClose={onDeleteStandardClose}
-        handleDiscardChanges={deleteStandard}
-        prompt={`Are you sure you want to delete ${card.title}?`}
-        subcontent="You will be unable to recover it after it has been deleted."
-        abandonActionText="Yes, delete standard"
-        confirmActionText="No, return to edit"
-        colorScheme="red"
-      />
     </>
   );
 };

--- a/src/components/Modals/CardModal/CardModalFormContent.jsx
+++ b/src/components/Modals/CardModal/CardModalFormContent.jsx
@@ -1,0 +1,378 @@
+import { ArrowUpIcon, CloseIcon } from "@chakra-ui/icons";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Tag,
+  Text,
+  useDisclosure,
+  Wrap,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useFormState } from "react-final-form";
+import useUser from "../../../lib/hooks/useUser";
+import ArrowIcon from "../../Carousel/ArrowIcon";
+import Carousel from "../../Carousel/Carousel";
+import InputControl from "../../FormComponents/InputControl";
+import TextareaControl from "../../FormComponents/TextareaControl";
+import ImagePreviewModal from "../ImagePreviewModal";
+import ModalImage from "../ModalImage";
+import AddImageModal from "./AddImageModal";
+import ConfirmActionsModal from "./ConfirmActionModal";
+
+const CardModalFormContent = ({
+  card,
+  setCards,
+  onCloseCardModal,
+  setValue,
+}) => {
+  const {
+    isOpen: isOpenImagePreviewModal,
+    onOpen: onOpenImagePreviewModal,
+    onClose: onCloseImagePreviewModal,
+  } = useDisclosure();
+
+  const {
+    isOpen: isDiscardChangesOpen,
+    onOpen: onDiscardChangesOpen,
+    onClose: onDiscardChangesClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isSaveChangesOpen,
+    onOpen: onSaveChangesOpen,
+    onClose: onSaveChangesClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isDeleteStandardOpen,
+    onOpen: onDeleteStandardOpen,
+    onClose: onDeleteStandardClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isImageDeleteOpen,
+    onOpen: onImageDeleteOpen,
+    onClose: onImageDeleteClose,
+  } = useDisclosure();
+
+  const [editing, setEditing] = useState(false);
+  const { user } = useUser();
+
+  const openImagePreviewCallback = () => {
+    onOpenImagePreviewModal();
+  };
+
+  const discardChanges = () => {
+    setEditing(false);
+    onDiscardChangesClose();
+  };
+
+  const saveChanges = () => {
+    console.log(form.dirtyFields, form.initialValues, form.dirty);
+    setEditing(false);
+    onSaveChangesClose();
+    onCloseCardModal();
+  };
+
+  const deleteStandard = () => {
+    setEditing(false);
+    onDeleteStandardClose();
+    onCloseCardModal();
+  };
+
+  const handleDeleteImage = (image) => {
+    const index = card.images.indexOf(image);
+    card.images.splice(index, 1);
+    onImageDeleteClose();
+  };
+
+  const form = useFormState();
+  return (
+    <>
+      <ModalOverlay />
+      <ModalContent rounded={14}>
+        <ModalCloseButton right={2} top={0} m={4} />
+        <ModalHeader mt={10} mx={6}>
+          <Flex justifyContent="space-between">
+            <Heading mb={2}>{card.title}</Heading>
+            {user.isAdmin ? (
+              !editing ? (
+                <Button
+                  bgColor="black"
+                  size="sm"
+                  p="1em"
+                  rounded="3xl"
+                  color="#ffffff"
+                  border="solid 2px #ffffff"
+                  width="auto"
+                  _hover={{ border: "solid 2px #6d6e70" }}
+                  onClick={() => {
+                    setEditing(true);
+                  }}
+                >
+                  Edit
+                </Button>
+              ) : (
+                <Flex gap={2} justifyContent="right">
+                  <Button
+                    bgColor="white"
+                    rounded="3xl"
+                    size="sm"
+                    color="#6d6e70"
+                    border="solid 1px #6d6e70"
+                    width="auto"
+                    onClick={onDiscardChangesOpen}
+                  >
+                    Discard Changes
+                  </Button>
+                  <Button
+                    bgColor="#00ACC8"
+                    rounded="3xl"
+                    size="sm"
+                    color="white"
+                    width="auto"
+                    _hover={{ bgColor: "#0690a7" }}
+                    _active={{ bgColor: "#057b8f" }}
+                    onClick={onSaveChangesOpen}
+                  >
+                    Save Changes
+                  </Button>
+                </Flex>
+              )
+            ) : (
+              <></>
+            )}
+          </Flex>
+        </ModalHeader>
+
+        <ModalBody mx={6}>
+          <Flex flexDirection="column">
+            <Carousel
+              cols={3}
+              rows={1}
+              gap={10}
+              containerStyle={{
+                marginBottom: "1.5rem",
+              }}
+              arrowLeft={<ArrowIcon orientation="left" />}
+              arrowRight={<ArrowIcon orientation="right" />}
+            >
+              {card.images.map(({ imageUrl: image }, index) => (
+                <Carousel.Item key={index}>
+                  <ModalImage
+                    editing={editing}
+                    image={image}
+                    openImagePreviewCallback={openImagePreviewCallback}
+                    onImageDeleteOpen={onImageDeleteOpen}
+                    isImageDeleteOpen={isImageDeleteOpen}
+                    onImageDeleteClose={onImageDeleteClose}
+                    handleDeleteImage={handleDeleteImage}
+                  />
+                </Carousel.Item>
+              ))}
+              {editing ? (
+                <Carousel.Item>
+                  <AddImageModal />
+                </Carousel.Item>
+              ) : (
+                <></>
+              )}
+            </Carousel>
+            {editing ? (
+              <TextareaControl name="criteria" resize="none"></TextareaControl>
+            ) : (
+              <Text lineHeight="normal" fontSize="18px">
+                {card.criteria}
+              </Text>
+            )}
+
+            <Flex
+              mt={3}
+              mb={15}
+              flexDirection="row"
+              gap="1rem"
+              alignItems="end"
+              width="full"
+            >
+              <Flex flexDirection="column" gap="1rem" width="full">
+                <Wrap overflowY="hidden" overflowX="hidden">
+                  {card.tags.map((tag, index) => (
+                    <Box key={index} position="relative">
+                      <Tag
+                        bgColor="#c4d600"
+                        borderRadius="30px"
+                        minWidth="fill"
+                        mt={editing ? "0.6rem" : "0rem"}
+                        fontSize="1rem"
+                        px="1rem"
+                      >
+                        {tag}
+                      </Tag>
+                      {editing ? (
+                        <Button
+                          position="absolute"
+                          top="0.2rem"
+                          right="-0.5rem"
+                          backgroundColor="#FFFFFF"
+                          color="#6D6E70"
+                          boxShadow="0 0 0.5rem #b3b3b3"
+                          size="xl"
+                          height="max"
+                          rounded="full"
+                          p="0.3rem"
+                          onClick={() => {
+                            const existingTags = card.tags;
+                            existingTags.splice(index, 1);
+                            setValue("newTags", existingTags);
+                          }}
+                        >
+                          <CloseIcon h={1.5} w={1.5} />
+                        </Button>
+                      ) : (
+                        <></>
+                      )}
+                    </Box>
+                  ))}
+                </Wrap>
+                {editing ? (
+                  <Flex
+                    border="solid 1px #B4B4B4B4"
+                    rounded="xl"
+                    alignItems="center"
+                    width="sm"
+                  >
+                    <InputControl
+                      name="newTag"
+                      type="text"
+                      rounded="2xl"
+                      border="none"
+                      focusBorderColor="transparent"
+                      placeholder="Add a Tag"
+                      width="full"
+                      onKeyDown={(e) => {
+                        if (e.code == "Enter") {
+                          if (form.values.newTag?.length > 0) {
+                            const existingTags = card.tags ? card.tags : [];
+                            existingTags.push(form.values.newTag.trim());
+                            setValue("newTag", "");
+                            setValue("newTags", existingTags);
+                          }
+                        }
+                      }}
+                    />
+                    <Button
+                      bgColor="transparent"
+                      rounded="full"
+                      width="max"
+                      height="max"
+                      p="0.2rem"
+                      mr="1rem"
+                      my="0.8rem"
+                      size="xl"
+                      border="solid 2px black"
+                      _hover={{ bgColor: "#f0f0f0" }}
+                      onClick={() => {
+                        const existingTags = card.tags ? card.tags : [];
+                        existingTags.push(form.values.newTag);
+                        setValue("newTag", "");
+                        setValue("newTags", existingTags);
+                      }}
+                    >
+                      <ArrowUpIcon h={4} w={4} color="black" />
+                    </Button>
+                  </Flex>
+                ) : (
+                  <></>
+                )}
+              </Flex>
+              <Flex gap={2} justifyContent="right" width="max">
+                {editing ? (
+                  <Button
+                    bgColor="#B90000"
+                    rounded="3xl"
+                    size="sm"
+                    color="#FFFFFF"
+                    border="solid 2px #FFFFFF"
+                    width="auto"
+                    _hover={{ border: "solid 2px #B90000" }}
+                    _active={{ bgColor: "#B90000" }}
+                    onClick={onDeleteStandardOpen}
+                  >
+                    Delete Standard
+                  </Button>
+                ) : (
+                  <>
+                    <Button
+                      bgColor="white"
+                      rounded="3xl"
+                      size="sm"
+                      color="#6d6e70"
+                      border="solid 1px #6d6e70"
+                      width="auto"
+                      onClick={openImagePreviewCallback}
+                    >
+                      View Notes
+                    </Button>
+                    <Button
+                      bgColor="#00ACC8"
+                      rounded="3xl"
+                      size="sm"
+                      color="white"
+                      width="auto"
+                      _hover={{ bgColor: "#0690a7" }}
+                      _active={{ bgColor: "#057b8f" }}
+                    >
+                      Add to Report
+                    </Button>
+                  </>
+                )}
+              </Flex>
+            </Flex>
+          </Flex>
+        </ModalBody>
+      </ModalContent>
+      <ImagePreviewModal
+        isOpen={isOpenImagePreviewModal}
+        onClose={onCloseImagePreviewModal}
+        card={card}
+        setCards={setCards}
+      />
+      <ConfirmActionsModal
+        isOpen={isDiscardChangesOpen}
+        onClose={onDiscardChangesClose}
+        handleAction={discardChanges}
+        prompt="Are you sure you want to discard all changes?"
+        subcontent="All progress will be lost."
+        confirmActionText="Yes, discard changes"
+        abandonActionText="No, return to edit"
+      />
+      <ConfirmActionsModal
+        isOpen={isSaveChangesOpen}
+        onClose={onSaveChangesClose}
+        handleAction={saveChanges}
+        prompt="Are you sure you want to save all changes?"
+        confirmActionText="Yes, save changes"
+        abandonActionText="No, return to edit"
+      />
+      <ConfirmActionsModal
+        isOpen={isDeleteStandardOpen}
+        onClose={onDeleteStandardClose}
+        handleAction={deleteStandard}
+        prompt={`Are you sure you want to delete ${card.title}?`}
+        subcontent="You will be unable to recover it after it has been deleted."
+        confirmActionText="Yes, delete standard"
+        abandonActionText="No, return to edit"
+        colorScheme="red"
+      />
+    </>
+  );
+};
+
+export default CardModalFormContent;

--- a/src/components/Modals/CardModal/CardModalFormContent.jsx
+++ b/src/components/Modals/CardModal/CardModalFormContent.jsx
@@ -338,9 +338,11 @@ const CardModalFormContent = ({
                             )
                               ? JSON.parse(JSON.stringify(form.values.tags))
                               : [];
-                            existingTags.push(form.values.newTag.trim());
-                            setValue("newTag", "");
-                            setValue("tags", existingTags);
+                            if (form.values?.newTag?.trim().length > 0) {
+                              existingTags.push(form.values.newTag.trim());
+                              setValue("newTag", "");
+                              setValue("tags", existingTags);
+                            }
                           }
                         }
                       }}
@@ -362,9 +364,11 @@ const CardModalFormContent = ({
                         )
                           ? JSON.parse(JSON.stringify(form.values.tags))
                           : [];
-                        existingTags.push(form.values.newTag.trim());
-                        setValue("newTag", "");
-                        setValue("tags", existingTags);
+                        if (form.values?.newTag?.trim().length > 0) {
+                          existingTags.push(form.values.newTag.trim());
+                          setValue("newTag", "");
+                          setValue("tags", existingTags);
+                        }
                       }}
                     >
                       <ArrowUpIcon h={4} w={4} color="black" />

--- a/src/components/Modals/CardModal/ConfirmActionModal.jsx
+++ b/src/components/Modals/CardModal/ConfirmActionModal.jsx
@@ -1,0 +1,105 @@
+import {
+  Button,
+  ButtonGroup,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+
+const DiscardChangesModal = ({
+  isOpen,
+  onClose,
+  prompt,
+  subcontent,
+  confirmActionText,
+  abandonActionText,
+  handleDiscardChanges,
+  colorScheme = "blue",
+}) => {
+  const colorSchemeProperties = {};
+  if (colorScheme == "blue") {
+    colorSchemeProperties.confirm = {
+      bgColor: "white",
+      color: "#6d6e70",
+    };
+    colorSchemeProperties.abandon = {
+      bgColor: "#00ACC8",
+      color: "white",
+      _hover: { bgColor: "#0690a7" },
+      _active: { bgColor: "#057b8f" },
+    };
+  } else if (colorScheme == "red") {
+    colorSchemeProperties.confirm = {
+      bgColor: "white",
+      color: "#6d6e70",
+    };
+    colorSchemeProperties.abandon = {
+      bgColor: "#B90000",
+      color: "white",
+      _hover: { border: "solid 2px #B90000" },
+      _active: { bgColor: "#B90000" },
+      border: "solid 2px #FFFFFF",
+    };
+  } else {
+    throw new Error("Color scheme does not exist for ConfirmActionModal");
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered={true}>
+      <ModalOverlay />
+      <ModalContent rounded={14}>
+        <ModalHeader
+          pt={10}
+          display="flex"
+          justifyContent="center"
+          textAlign="center"
+          fontSize="2xl"
+        >
+          {prompt}
+        </ModalHeader>
+        <ModalCloseButton />
+        {subcontent ? (
+          <ModalBody display="flex" justifyContent="center" textAlign="center">
+            <Text>{subcontent}</Text>
+          </ModalBody>
+        ) : (
+          <></>
+        )}
+
+        <ModalFooter justifyContent="center" pb={10}>
+          <ButtonGroup>
+            <Button
+              bgColor="white"
+              size="sm"
+              rounded={16}
+              color="#6d6e70"
+              border="solid 1px #6d6e70"
+              fontSize="md"
+              width="auto"
+              onClick={onClose}
+            >
+              {confirmActionText}
+            </Button>
+            <Button
+              {...colorSchemeProperties.abandon}
+              size="sm"
+              rounded={16}
+              fontSize="md"
+              width="auto"
+              onClick={handleDiscardChanges}
+            >
+              {abandonActionText}
+            </Button>
+          </ButtonGroup>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DiscardChangesModal;

--- a/src/components/Modals/CardModal/ConfirmActionModal.jsx
+++ b/src/components/Modals/CardModal/ConfirmActionModal.jsx
@@ -8,37 +8,38 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Text,
 } from "@chakra-ui/react";
 
-const DiscardChangesModal = ({
+const ConfirmActionModal = ({
   isOpen,
   onClose,
   prompt,
   subcontent,
   confirmActionText,
   abandonActionText,
-  handleDiscardChanges,
+  handleAction,
   colorScheme = "blue",
 }) => {
   const colorSchemeProperties = {};
   if (colorScheme == "blue") {
-    colorSchemeProperties.confirm = {
+    colorSchemeProperties.abandon = {
       bgColor: "white",
       color: "#6d6e70",
+      border: "solid 1px #6d6e70",
     };
-    colorSchemeProperties.abandon = {
+    colorSchemeProperties.confirm = {
       bgColor: "#00ACC8",
       color: "white",
       _hover: { bgColor: "#0690a7" },
       _active: { bgColor: "#057b8f" },
     };
   } else if (colorScheme == "red") {
-    colorSchemeProperties.confirm = {
+    colorSchemeProperties.abandon = {
       bgColor: "white",
       color: "#6d6e70",
+      border: "solid 1px #6d6e70",
     };
-    colorSchemeProperties.abandon = {
+    colorSchemeProperties.confirm = {
       bgColor: "#B90000",
       color: "white",
       _hover: { border: "solid 2px #B90000" },
@@ -65,7 +66,7 @@ const DiscardChangesModal = ({
         <ModalCloseButton />
         {subcontent ? (
           <ModalBody display="flex" justifyContent="center" textAlign="center">
-            <Text>{subcontent}</Text>
+            {subcontent}
           </ModalBody>
         ) : (
           <></>
@@ -74,26 +75,24 @@ const DiscardChangesModal = ({
         <ModalFooter justifyContent="center" pb={10}>
           <ButtonGroup>
             <Button
-              bgColor="white"
-              size="sm"
-              rounded={16}
-              color="#6d6e70"
-              border="solid 1px #6d6e70"
-              fontSize="md"
-              width="auto"
-              onClick={onClose}
-            >
-              {confirmActionText}
-            </Button>
-            <Button
               {...colorSchemeProperties.abandon}
               size="sm"
               rounded={16}
               fontSize="md"
               width="auto"
-              onClick={handleDiscardChanges}
+              onClick={onClose}
             >
               {abandonActionText}
+            </Button>
+            <Button
+              {...colorSchemeProperties.confirm}
+              size="sm"
+              rounded={16}
+              fontSize="md"
+              width="auto"
+              onClick={handleAction}
+            >
+              {confirmActionText}
             </Button>
           </ButtonGroup>
         </ModalFooter>
@@ -102,4 +101,4 @@ const DiscardChangesModal = ({
   );
 };
 
-export default DiscardChangesModal;
+export default ConfirmActionModal;

--- a/src/components/Modals/CardModal/cardEditValidator.js
+++ b/src/components/Modals/CardModal/cardEditValidator.js
@@ -1,0 +1,11 @@
+const cardEditValidator = (values) => {
+  const errors = {};
+  if (!values.notes) {
+    errors.tags = "Required";
+  }
+  if (!values.images) {
+    errors.lastName = "One image minimum is required";
+  }
+  return errors;
+};
+export default cardEditValidator;

--- a/src/components/Modals/CardModal/cardEditValidator.js
+++ b/src/components/Modals/CardModal/cardEditValidator.js
@@ -1,10 +1,10 @@
 const cardEditValidator = (values) => {
   const errors = {};
-  if (!values.notes) {
-    errors.tags = "Required";
+  if (!values.criteria) {
+    errors.criteria = "Criteria is are required";
   }
   if (!values.images) {
-    errors.lastName = "One image minimum is required";
+    errors.images = "One image minimum is required";
   }
   return errors;
 };

--- a/src/components/Modals/CardModal/cardEditValidator.js
+++ b/src/components/Modals/CardModal/cardEditValidator.js
@@ -1,10 +1,29 @@
+import { isValidBlobUrl } from "src/lib/utils/blobStorage";
+
 const cardEditValidator = (values) => {
   const errors = {};
-  if (!values.criteria) {
-    errors.criteria = "Criteria is are required";
+  if (!values.criteria || values.criteria.length == 0) {
+    errors.criteria = "Criteria cannot be blank";
   }
   if (!values.images) {
     errors.images = "One image minimum is required";
+  }
+  if (values.images) {
+    if (values.images.length == 0) {
+      errors.images = "One image minimum is required";
+    }
+    for (let image of values.images) {
+      if (!isValidBlobUrl(image.imageUrl)) {
+        errors.images = "An image has an invalid url";
+      }
+    }
+  }
+  if (values.tags) {
+    for (let tag of values.tags) {
+      if (tag.length == 0) {
+        errors.tags = "Cannot add empty tag";
+      }
+    }
   }
   return errors;
 };

--- a/src/components/Modals/ModalImage/ModalImage.jsx
+++ b/src/components/Modals/ModalImage/ModalImage.jsx
@@ -1,36 +1,80 @@
-import { Box, Button } from "@chakra-ui/react";
-
-import { MdExpand } from "react-icons/md";
-
+import { CloseIcon } from "@chakra-ui/icons";
+import { Box, Button, Text } from "@chakra-ui/react";
 import Image from "next/image";
+import { MdExpand } from "react-icons/md";
+import ConfirmActionsModal from "../CardModal/ConfirmActionModal";
 
 const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
   return (
-    <Box position="relative" {...props}>
-      <Box boxShadow="lg" margin="0 .3rem .5rem 0">
-        <Image
-          src={image}
-          layout="responsive"
-          width="100%"
-          height="100%"
-          alt={"card image"}
-        />
+    <>
+      <Box position="relative" {...props}>
+        <Box boxShadow="lg" margin="0 .3rem .5rem 0">
+          <Image
+            src={image}
+            layout="responsive"
+            width="100%"
+            height="100%"
+            alt={"card image"}
+          />
+        </Box>
+        <Button
+          leftIcon={<MdExpand />}
+          position="absolute"
+          bottom="1rem"
+          borderRadius="1rem"
+          right="1rem"
+          height={7}
+          backgroundColor="#FFFFFF"
+          color="#6D6E70"
+          boxShadow="xl"
+          onClick={openImagePreviewCallback}
+        >
+          Enlarge Image
+        </Button>
+        {props.editing ? (
+          <Button
+            position="absolute"
+            top="0.25rem"
+            right="0rem"
+            backgroundColor="#FFFFFF"
+            color="#6D6E70"
+            boxShadow="0 0 0.5rem #b3b3b3"
+            size="xl"
+            height="max"
+            rounded="full"
+            p="0.6rem"
+            onClick={props.onImageDeleteOpen}
+          >
+            <CloseIcon h={3} w={3} />
+          </Button>
+        ) : (
+          <></>
+        )}
       </Box>
-      <Button
-        leftIcon={<MdExpand />}
-        position="absolute"
-        bottom="1rem"
-        borderRadius="1rem"
-        right="1rem"
-        height={7}
-        backgroundColor="#FFFFFF"
-        color="#6D6E70"
-        boxShadow="xl"
-        onClick={openImagePreviewCallback}
-      >
-        Enlarge Image
-      </Button>
-    </Box>
+      <ConfirmActionsModal
+        isOpen={props.isImageDeleteOpen}
+        onClose={props.onImageDeleteClose}
+        handleDiscardChanges={() => {}}
+        prompt="Are you sure you want to delete this image?"
+        subcontent={
+          <Box>
+            <Image
+              src={image}
+              layout="responsive"
+              width="25px"
+              height="25px"
+              alt={"card image"}
+            />
+            <Text>
+              You will be unable to recover it after it has been deleted.
+            </Text>
+          </Box>
+        }
+        abandonActionText="Yes, delete standard"
+        confirmActionText="No, return to edit"
+        colorScheme="red"
+      />
+    </>
   );
 };
 

--- a/src/components/Modals/ModalImage/ModalImage.jsx
+++ b/src/components/Modals/ModalImage/ModalImage.jsx
@@ -5,6 +5,9 @@ import { MdExpand } from "react-icons/md";
 import ConfirmActionsModal from "../CardModal/ConfirmActionModal";
 
 const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
+  const imagePath = new URL(image).pathname.split("/");
+  const filename = imagePath[imagePath.length - 1];
+
   return (
     <>
       <Box position="relative" {...props}>
@@ -54,15 +57,19 @@ const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
       <ConfirmActionsModal
         isOpen={props.isImageDeleteOpen}
         onClose={props.onImageDeleteClose}
-        handleDiscardChanges={() => {}}
+        handleAction={() => {
+          props.handleDeleteImage(image);
+        }}
         prompt="Are you sure you want to delete this image?"
         subcontent={
           <Box>
+            <Text fontSize="lg" color="gray.500">
+              {filename}
+            </Text>
             <Image
               src={image}
-              layout="responsive"
-              width="25px"
-              height="25px"
+              width="100px"
+              height="100px"
               alt={"card image"}
             />
             <Text>
@@ -70,8 +77,8 @@ const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
             </Text>
           </Box>
         }
-        abandonActionText="Yes, delete standard"
-        confirmActionText="No, return to edit"
+        confirmActionText="Yes, delete image"
+        abandonActionText="No, return to edit"
         colorScheme="red"
       />
     </>

--- a/src/components/Modals/ModalImage/ModalImage.jsx
+++ b/src/components/Modals/ModalImage/ModalImage.jsx
@@ -4,7 +4,16 @@ import Image from "next/image";
 import { MdExpand } from "react-icons/md";
 import ConfirmActionsModal from "../CardModal/ConfirmActionModal";
 
-const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
+const ModalImage = ({
+  image,
+  openImagePreviewCallback,
+  editing,
+  handleDeleteImage,
+  isImageDeleteOpen,
+  onImageDeleteClose,
+  onImageDeleteOpen,
+  ...props
+}) => {
   const imagePath = new URL(image).pathname.split("/");
   const filename = imagePath[imagePath.length - 1];
 
@@ -34,7 +43,7 @@ const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
         >
           Enlarge Image
         </Button>
-        {props.editing ? (
+        {editing ? (
           <Button
             position="absolute"
             top="0.25rem"
@@ -46,7 +55,7 @@ const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
             height="max"
             rounded="full"
             p="0.6rem"
-            onClick={props.onImageDeleteOpen}
+            onClick={onImageDeleteOpen}
           >
             <CloseIcon h={3} w={3} />
           </Button>
@@ -55,10 +64,10 @@ const ModalImage = ({ image, openImagePreviewCallback, ...props }) => {
         )}
       </Box>
       <ConfirmActionsModal
-        isOpen={props.isImageDeleteOpen}
-        onClose={props.onImageDeleteClose}
+        isOpen={isImageDeleteOpen}
+        onClose={onImageDeleteClose}
         handleAction={() => {
-          props.handleDeleteImage(image);
+          handleDeleteImage(image);
         }}
         prompt="Are you sure you want to delete this image?"
         subcontent={

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -16,7 +16,7 @@ import { updateRecentStandardsRequest } from "../../actions/User";
 import useUser from "../../lib/hooks/useUser";
 import CardModal from "../Modals/CardModal";
 
-const StandardCard = ({ card, setCards, ...props }) => {
+const StandardCard = ({ card, cards, setCards, ...props }) => {
   const { user } = useUser();
   const {
     isOpen: isOpenCardModal,
@@ -119,6 +119,7 @@ const StandardCard = ({ card, setCards, ...props }) => {
           isOpenCardModal={isOpenCardModal}
           onCloseCardModal={onCloseCardModal}
           card={card}
+          cards={cards}
           setCards={setCards}
         />
       </Flex>

--- a/src/components/StandardCardTable/StandardCardTable.jsx
+++ b/src/components/StandardCardTable/StandardCardTable.jsx
@@ -60,7 +60,7 @@ const StandardCardTable = ({ cards, setCards, ...props }) => {
       >
         {cards.map((card, index) => (
           <GridItem w="100%" key={index}>
-            <StandardCard card={card} setCards={setCards} />
+            <StandardCard card={card} setCards={setCards} cards={cards} />
           </GridItem>
         ))}
       </Grid>

--- a/src/lib/utils/blobStorage.js
+++ b/src/lib/utils/blobStorage.js
@@ -10,22 +10,26 @@ const getBlobClient = () => {
 };
 
 const uploadFile = async (blobName, content, metadata, tags) => {
-  const containerClient = getBlobClient();
+  try {
+    const containerClient = getBlobClient();
 
-  const blockBlobClient = containerClient.getBlockBlobClient(blobName);
-  const options = {
-    blobHTTPHeaders: {
-      blobContentType: content.type,
-    },
-    metadata: metadata,
-    tags: tags,
-  };
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+    const options = {
+      blobHTTPHeaders: {
+        blobContentType: content.type,
+      },
+      metadata: metadata,
+      tags: tags,
+    };
 
-  const uploadBlobResponse = await blockBlobClient.uploadBrowserData(
-    content,
-    options
-  );
-  return uploadBlobResponse;
+    const uploadBlobResponse = await blockBlobClient.uploadData(
+      content,
+      options
+    );
+    return uploadBlobResponse;
+  } catch (e) {
+    return e;
+  }
 };
 
 const listBlobs = async () => {
@@ -39,4 +43,15 @@ const listBlobs = async () => {
   return blobs;
 };
 
-export { uploadFile, listBlobs };
+function isValidBlobUrl(url) {
+  try {
+    var urlObject = new URL(url);
+    var isAzure = urlObject.host.endsWith(".blob.core.windows.net");
+    // urlObject.protocol === "blob:" &&
+    return isAzure;
+  } catch (e) {
+    return false;
+  }
+}
+
+export { uploadFile, listBlobs, isValidBlobUrl };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.15.4":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -4757,6 +4764,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+final-form@^4.20.9:
+  version "4.20.9"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.9.tgz#647b459f8c504d77ec8f6e280015ab172982af2f"
+  integrity sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==
+  dependencies:
+    "@babel/runtime" "^7.10.0"
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -7072,6 +7086,13 @@ react-fast-compare@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-final-form@^6.5.9:
+  version "6.5.9"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.9.tgz#644797d4c122801b37b58a76c87761547411190b"
+  integrity sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
 
 react-focus-lock@^2.9.2:
   version "2.9.2"


### PR DESCRIPTION
## Editing + Deleting A Standard (Admin)

Issue Number(s): #98

What does this PR change and why?
This PR adds the edit view on clicking standards for admins. It allows you to change the fields of the standard in the card view. This is so admins can edit the standards quickly and easily from the main library view. It also allows them to delete standards.

### Checklist
- [x] Edit button is shown for admin users (just check user.isAdmin from useUser hook)
- [x] OnClick of edit, it renders the components as editable (look into the editable chakra UI component + talk to Alex)
- [x] All of the editing is done using [ReactFinalForm](https://final-form.org/react) again talk to Alex 
- [x] onClick of delete standard button, it deletes the entire standard (modify frontend and database)
- [x] all relevant "are you sure" modals are displayed
- [x] if fields are left empty, error states are shown (look into it with react final form)
- [x] all relevant backend database query/mutations are updated (database reflects changes)
- [ ] add image popup/uploading

### How to Test
- Go to http://localhost:3000/library/single-family/durability-and-moisture-management
- Sign out
- Click a standard
- See if there's an edit button, there shouldn't be one
- Log in as admin
- Click the standard again
- Click edit
- Change a bunch of fields (Criteria, tags, images, should all update)
- Click save
- Confirm
- Check that every major action has a confirm dialogue (Delete, edit)
- Check to see card is updated with the right info
- Click the standard again
- Check that delete works

### Notes
Add image functionality is there, just authentication is broken
There's no logic to check if a tag is valid or not and this is only a problem because for some reason you aren't supposed to be able to add new tags.