### PR TITLE
ah/117-filter-search-by-tags

### DIFF
--- a/src/actions/Card.js
+++ b/src/actions/Card.js
@@ -48,7 +48,7 @@ export const getCardsPagination = async (pageNumber, searchFilter) => {
   let url = urls.api.card.getPagination + pageNumber;
 
   if (searchFilter) {
-    const tagsArray = Object.keys(searchFilter.tags);
+    const tagsArray = searchFilter.tags.map((t) => t.toLowerCase());
 
     url +=
       "&searchFilterString=" +

--- a/src/components/PaginationTab/PaginationTab.jsx
+++ b/src/components/PaginationTab/PaginationTab.jsx
@@ -1,5 +1,5 @@
 import { Button, Flex } from "@chakra-ui/react";
-import useSearch from "../SearchBar/useSearch";
+import useSearch from "src/lib/hooks/useSearch";
 
 const PaginationTab = ({
   numPages,

--- a/src/components/SearchBar/CurrentSearchInfo.jsx
+++ b/src/components/SearchBar/CurrentSearchInfo.jsx
@@ -1,0 +1,70 @@
+import { CloseIcon } from "@chakra-ui/icons";
+import { Box, HStack, IconButton, Tag, Text, Wrap } from "@chakra-ui/react";
+
+const CurrentSearchInfo = ({
+  handleSearch,
+  searchString,
+  location,
+  tags,
+  setResetSearch,
+  setTagToClear,
+}) => {
+  const clearTags = () => {
+    setResetSearch(true);
+    handleSearch({ searchString: searchString, tags: [] });
+  };
+
+  const clearSingleTag = (tagToClear) => {
+    setTagToClear(tagToClear);
+    const newArray = tags ? tags.filter((tag) => tag !== tagToClear) : null;
+    handleSearch({ searchString: searchString, tags: newArray });
+  };
+
+  if (searchString === "" && tags.length == 0) {
+    return;
+  }
+  return (
+    <Box mt={5} mb={0}>
+      {searchString !== "" && (
+        <Text fontSize="lg" fontWeight="500">
+          You searched for &quot;{searchString}&quot; in {location}
+        </Text>
+      )}
+      {tags.length > 0 && (
+        <HStack gap={1} my={2}>
+          <Wrap>
+            {tags.map((tag, idx) => {
+              return (
+                <Tag key={idx} py={1} bgColor="#F2F2F2">
+                  <Text pr={2} color="Grey">
+                    {tag}
+                  </Text>
+                  <IconButton
+                    icon={<CloseIcon />}
+                    variant="unstyled"
+                    size="xs"
+                    color="Grey"
+                    onClick={() => clearSingleTag(tag)}
+                  />
+                </Tag>
+              );
+            })}
+            <Text
+              as="u"
+              color="Blue"
+              cursor="pointer"
+              fontWeight="500"
+              display="flex"
+              alignItems="center"
+              onClick={clearTags}
+            >
+              Clear all
+            </Text>
+          </Wrap>
+        </HStack>
+      )}
+    </Box>
+  );
+};
+
+export default CurrentSearchInfo;

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -1,4 +1,9 @@
-import { CloseIcon, Icon, SearchIcon } from "@chakra-ui/icons";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  Icon,
+  SearchIcon,
+} from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -6,62 +11,88 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
-  Popover,
-  PopoverArrow,
-  PopoverContent,
-  PopoverTrigger,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
-import { Form } from "react-final-form";
+import { Form, useForm, useFormState } from "react-final-form";
 import { FaLongArrowAltRight } from "react-icons/fa";
 import Tag from "../Tag";
 
-const SearchBar = (props) => {
-  const { handleSearch, ...rest } = props;
-  const [isClickedSearch, setIsClickedSearch] = useState(false);
-  const [searchInput, setSearchInput] = useState("");
+const SearchBarComponent = (props) => {
+  const {
+    resetSearch,
+    setResetSearch,
+    handleSubmit,
+    isClickedSearch,
+    searchInput,
+    setSearchInput,
+    tagToClear,
+    setTagToClear,
+    ...rest
+  } = props;
+
+  const { values } = useFormState();
+  const { mutators } = useForm();
+
+  const { isOpen, onToggle } = useDisclosure();
 
   useEffect(() => {
-    if (searchInput === "") {
-      setIsClickedSearch(false);
+    if (resetSearch) {
+      mutators.setValue("tagArray", null);
+      setResetSearch(false);
     }
-  }, [searchInput]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetSearch, setResetSearch]);
 
-  const handleSearchButtonClick = () => {
-    setIsClickedSearch(true);
-    handleSearch({ searchString: searchInput });
-  };
+  useEffect(() => {
+    const newArray = values.tagArray
+      ? values.tagArray.filter((tag) => tag !== tagToClear)
+      : null;
+    mutators.setValue("tagArray", newArray);
+    setTagToClear(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tagToClear, setTagToClear]);
 
-  const handleExitSearchButtonClick = () => {
-    handleSearch({});
-    setSearchInput("");
-    setIsClickedSearch(false);
+  const handleApplyFiltersClick = (handleSubmit) => {
+    onToggle();
+    handleSubmit();
   };
 
   const handleSearchInputChange = (e) => {
     setSearchInput(e.target.value);
   };
 
-  const SearchButton = () =>
-    isClickedSearch ? (
-      <Button
-        variant="Blue"
-        size="lg"
-        mr="3"
-        onClick={handleExitSearchButtonClick}
-      >
-        <CloseIcon boxSize="12px" />
-      </Button>
-    ) : (
-      <Button variant="Blue" size="lg" mr="3" onClick={handleSearchButtonClick}>
+  const getNumTagsFiltered = (values) => {
+    return isClickedSearch && values.tagArray && values.tagArray.length > 0
+      ? `(${values.tagArray.length})`
+      : "";
+  };
+
+  const SearchButton = ({ handleSubmit }) => {
+    return (
+      <Button variant="Blue" size="lg" mr="3" onClick={handleSubmit}>
         <FaLongArrowAltRight />
       </Button>
     );
+  };
 
   return (
     <Flex {...rest} justifyContent="flex-end">
       {/* search bar */}
-      <Box mr="1">
+      <Box
+        position="absolute"
+        right={
+          isClickedSearch && values.tagArray && values.tagArray.length > 0
+            ? "15em"
+            : "13em"
+        }
+      >
         <InputGroup size="lg" borderWidth="">
           <InputLeftAddon bg="transparent" borderRight="none">
             <Icon as={SearchIcon} />
@@ -73,23 +104,117 @@ const SearchBar = (props) => {
           />
         </InputGroup>
       </Box>
+
+      {/* Filter tab */}
       <Box mr="3">
-        <Popover placement="bottom-end">
-          <PopoverTrigger>
-            <Button variant="Grey-outlined" size="lg">
-              Filter
+        <Tabs variant="enclosed" h="full" align="end">
+          {isOpen ? (
+            <TabList>
+              <Box
+                border="1px solid Grey"
+                borderBottom="none"
+                roundedTop={8}
+                roundedBottom={0}
+              >
+                <Tab
+                  color="Grey"
+                  bgColor="#F2F2F2"
+                  border="none"
+                  onClick={onToggle}
+                  fontSize="lg"
+                  px={4}
+                  pb={isOpen ? 5 : 3}
+                >
+                  <Text pr={3}>Filter {getNumTagsFiltered(values)}</Text>
+                  <ChevronUpIcon />
+                </Tab>
+              </Box>
+            </TabList>
+          ) : (
+            <Button
+              p={4}
+              pt={3}
+              rounded={8}
+              bgColor="#F2F2F2"
+              color="Grey"
+              border="1px solid Grey"
+              _hover={{ bgColor: "#d9d9d9" }}
+              _active={{ bgColor: "#c1c1c1" }}
+              size="lg"
+              fontSize="lg"
+              onClick={onToggle}
+            >
+              <Text pr={3}>Filter {getNumTagsFiltered(values)}</Text>
+              <ChevronDownIcon />
             </Button>
-          </PopoverTrigger>
-          <PopoverContent width={{ base: "75em", "2xl": "80em" }}>
-            <PopoverArrow />
-            <Form onSubmit={() => console.log("submitting")}>
-              {() => <Tag height={{ base: "45em", "2xl": "55em" }} />}
-            </Form>
-          </PopoverContent>
-        </Popover>
+          )}
+          <TabPanels
+            display={isOpen ? "initial" : "none"}
+            backgroundColor="#F2F2F2"
+            mr="-100px"
+          >
+            <TabPanel
+              width={{ base: "75em", "2xl": "80em" }}
+              border="1px solid Grey"
+              rounded={8}
+              roundedTopRight={0}
+              bgColor="#F2F2F2"
+              position="relative"
+            >
+              <Tag height="65vh" overflow="auto" />
+              <Button
+                p={4}
+                variant="Blue"
+                pos="absolute"
+                right="2em"
+                bottom="2em"
+                onClick={() => handleApplyFiltersClick(handleSubmit)}
+              >
+                Apply Filters {getNumTagsFiltered(values)}
+              </Button>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
       </Box>
-      <SearchButton />
+      {/* Submit search button */}
+      <SearchButton handleSubmit={handleSubmit} />
     </Flex>
+  );
+};
+
+const SearchBar = (props) => {
+  const [searchInput, setSearchInput] = useState("");
+  const [isClickedSearch, setIsClickedSearch] = useState(false);
+
+  const handleSearchButtonClick = (values) => {
+    values.tagArray && values.tagArray.length == 0
+      ? setIsClickedSearch(false)
+      : setIsClickedSearch(true);
+    props.handleSearch({
+      searchString: searchInput,
+      tags: values.tagArray || [],
+    });
+  };
+
+  return (
+    <Form
+      onSubmit={handleSearchButtonClick}
+      mutators={{
+        setValue: ([field, value], state, { changeValue }) => {
+          changeValue(state, field, () => value);
+        },
+      }}
+    >
+      {({ handleSubmit }) => (
+        <SearchBarComponent
+          handleSubmit={handleSubmit}
+          isClickedSearch={isClickedSearch}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+          {...props}
+        />
+      )}
+    </Form>
   );
 };
 

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,8 +1,7 @@
 import SearchBar from "./SearchBar";
 import useTextFilter from "./useTextFilter";
 import useTagsFilter from "./useTagsFilter";
-import useSearch from "./useSearch";
 
 export default SearchBar;
 
-export { useTextFilter, useTagsFilter, useSearch };
+export { useTextFilter, useTagsFilter };

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -8,23 +8,21 @@ const Tag = (props) => {
   const tags = data?.payload[0];
 
   return (
-    <>
-      <Flex {...props} direction="column" wrap="wrap">
-        {tags &&
-          Object.keys(tags).map((letter) => {
-            return (
-              <Box key={letter}>
-                <TagBox
-                  key={letter}
-                  letter={letter}
-                  list={tags[letter]}
-                  isTruncated
-                />
-              </Box>
-            );
-          })}
-      </Flex>
-    </>
+    <Flex {...props} direction="column" wrap="wrap">
+      {tags &&
+        Object.keys(tags).map((letter) => {
+          return (
+            <Box key={letter}>
+              <TagBox
+                key={letter}
+                letter={letter}
+                list={tags[letter]}
+                isTruncated
+              />
+            </Box>
+          );
+        })}
+    </Flex>
   );
 };
 

--- a/src/lib/hooks/useSearch.js
+++ b/src/lib/hooks/useSearch.js
@@ -1,11 +1,19 @@
 import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { getCardsPagination } from "../../actions/Card";
 
 export default function useSearch({ setNumPages, setCurrentPage, setCards }) {
   const router = useRouter();
   const noSearchResultsToast = useToast();
   const { buildingType, primaryCategory } = router.query;
+
+  const [searchString, setSearchString] = useState("");
+  const [tags, setTags] = useState([]);
+  const [pageNumber, setPageNumber] = useState(1);
+
+  const [resetSearch, setResetSearch] = useState(false);
+  const [tagToClear, setTagToClear] = useState();
 
   const calculateNumPagesToDisplay = (cardsCount) => {
     if (setNumPages) {
@@ -30,7 +38,7 @@ export default function useSearch({ setNumPages, setCurrentPage, setCards }) {
 
   const handleSearch = async ({
     searchString = "",
-    tags = {},
+    tags = [],
     pageNumber = 1,
   }) => {
     const searchFilter = {
@@ -40,8 +48,14 @@ export default function useSearch({ setNumPages, setCurrentPage, setCards }) {
       primaryCategory: primaryCategory || null,
     };
 
+    console.log(searchFilter);
+
     // accounts for click button on primary category page with empty string
-    if (searchString === "" && primaryCategory === undefined) {
+    if (
+      searchString === "" &&
+      tags.length == 0 &&
+      primaryCategory === undefined
+    ) {
       setCards([]);
     } else {
       const { cards, cardsCount } = await getCardsPagination(
@@ -58,7 +72,20 @@ export default function useSearch({ setNumPages, setCurrentPage, setCards }) {
         displayNoSearchResultToast();
       }
     }
+
+    setSearchString(searchString);
+    setTags(tags);
+    setPageNumber(pageNumber);
   };
 
-  return { handleSearch };
+  return {
+    handleSearch,
+    searchString,
+    tags,
+    pageNumber,
+    resetSearch,
+    setResetSearch,
+    tagToClear,
+    setTagToClear,
+  };
 }

--- a/src/pages/api/card/getPagination.js
+++ b/src/pages/api/card/getPagination.js
@@ -10,12 +10,8 @@ const handler = async (req, res) => {
     const pageNumber = req.query.page - 1;
     const buildingType = req.query.buildingType;
     const primaryCategory = req.query.primaryCategory;
-    const searchFilterString = req.query.searchFilterString
-      ? req.query.searchFilterString
-      : null;
-    const searchFilterTags = req.query.searchFilterTags
-      ? req.query.searchFilterTags.split(",")
-      : null;
+    const searchFilterString = req.query.searchFilterString || null;
+    const searchFilterTags = req.query.searchFilterTags || null;
 
     const cards = await getCardsPagination({
       pageNumber,

--- a/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
+++ b/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
@@ -1,15 +1,17 @@
 import {
+  Box,
   Breadcrumb,
   BreadcrumbItem,
   Flex,
   Heading,
+  HStack,
   Text,
 } from "@chakra-ui/react";
 import Link from "next/link";
 import { useState } from "react";
 import { getCardsCount, getCardsPagination } from "server/mongodb/actions/Card";
 import PaginationTab from "src/components/PaginationTab";
-import SearchBar, { useSearch } from "src/components/SearchBar";
+import SearchBar from "src/components/SearchBar";
 import StandardCardTable from "src/components/StandardCardTable";
 import {
   buildingTypeNames,
@@ -19,6 +21,8 @@ import {
   capitalizeAndRemoveDash,
   uncapitalizeAndAddDash,
 } from "src/lib/utils/utilFunctions";
+import CurrentSearchInfo from "src/components/SearchBar/CurrentSearchInfo";
+import useSearch from "src/lib/hooks/useSearch";
 
 const LibraryCategoryPage = (props) => {
   const cardsFromDatabase = props.cardsFromDatabase;
@@ -28,24 +32,61 @@ const LibraryCategoryPage = (props) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [numPages, setNumPages] = useState(numPagesInitial);
 
-  const { handleSearch } = useSearch({ setNumPages, setCurrentPage, setCards });
+  const {
+    handleSearch,
+    searchString,
+    tags,
+    resetSearch,
+    setResetSearch,
+    tagToClear,
+    setTagToClear,
+  } = useSearch({
+    setNumPages,
+    setCurrentPage,
+    setCards,
+  });
 
   return (
     <Flex alignItems="stretch" flexDirection="column" p="2rem">
-      <Breadcrumb separator=">" fontWeight="semibold" pb="5">
-        <BreadcrumbItem>
-          <Link href="/library">Digital Library</Link>
-        </BreadcrumbItem>
-        <BreadcrumbItem>
-          <Link href={`/library/${props.params.buildingType}`}>
-            {props.buildingType}
-          </Link>
-        </BreadcrumbItem>
-        <BreadcrumbItem>
-          <Text>{props.primaryCategory}</Text>
-        </BreadcrumbItem>
-      </Breadcrumb>
-      <SearchBar handleSearch={handleSearch} />
+      <HStack w="full" position="relative">
+        <Breadcrumb
+          separator=">"
+          fontWeight="semibold"
+          position="absolute"
+          top={2}
+        >
+          <BreadcrumbItem>
+            <Link href="/library">Digital Library</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Link href={`/library/${props.params.buildingType}`}>
+              {props.buildingType}
+            </Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Text>{props.primaryCategory}</Text>
+          </BreadcrumbItem>
+        </Breadcrumb>
+
+        <Box flex="1"></Box>
+
+        <SearchBar
+          handleSearch={handleSearch}
+          resetSearch={resetSearch}
+          tagToClear={tagToClear}
+          setTagToClear={setTagToClear}
+          setResetSearch={setResetSearch}
+        />
+      </HStack>
+
+      <CurrentSearchInfo
+        handleSearch={handleSearch}
+        searchString={searchString}
+        location={props.primaryCategory}
+        tags={tags}
+        setResetSearch={setResetSearch}
+        setTagToClear={setTagToClear}
+      />
 
       {numPages > 0 ? (
         <>
@@ -60,7 +101,7 @@ const LibraryCategoryPage = (props) => {
           />
         </>
       ) : (
-        <Heading>No Cards Found</Heading>
+        <Heading my={10}>No Cards Found</Heading>
       )}
     </Flex>
   );

--- a/src/pages/library/[buildingType]/index.jsx
+++ b/src/pages/library/[buildingType]/index.jsx
@@ -1,12 +1,21 @@
-import { Breadcrumb, BreadcrumbItem, Flex, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  Flex,
+  HStack,
+  Text,
+} from "@chakra-ui/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { getCardsCount, getCardsPagination } from "server/mongodb/actions/Card";
 import CategoryCards from "src/components/CategoryCards";
-import SearchBar, { useSearch } from "src/components/SearchBar";
+import SearchBar from "src/components/SearchBar";
 import StandardCardTable from "src/components/StandardCardTable";
 import { buildingTypeNames } from "src/lib/utils/constants";
+import CurrentSearchInfo from "src/components/SearchBar/CurrentSearchInfo";
+import useSearch from "src/lib/hooks/useSearch";
 
 function CategoriesPage({ buildingType }) {
   const router = useRouter();
@@ -16,32 +25,57 @@ function CategoriesPage({ buildingType }) {
   // eslint-disable-next-line no-unused-vars
   const [currentPage, setCurrentPage] = useState(1);
 
-  const { handleSearch } = useSearch({
+  const {
+    handleSearch,
+    searchString,
+    tags,
+    resetSearch,
+    setResetSearch,
+    tagToClear,
+    setTagToClear,
+  } = useSearch({
     setNumPages,
     setCurrentPage,
     setCards,
   });
 
   return (
-    <Flex
-      padding="2rem"
-      flexDirection="column"
-      gap="2rem"
-      fontWeight="semibold"
-    >
-      <Breadcrumb separator=">">
-        <BreadcrumbItem>
-          <Link href="/library">Digital Library</Link>
-        </BreadcrumbItem>
-        <BreadcrumbItem>
-          <Text>{buildingType}</Text>
-        </BreadcrumbItem>
-      </Breadcrumb>
-      <SearchBar handleSearch={handleSearch} />
+    <Flex padding="2rem" flexDirection="column">
+      <HStack w="full" position="relative">
+        <Breadcrumb
+          separator=">"
+          fontWeight="semibold"
+          position="absolute"
+          top={3}
+        >
+          <BreadcrumbItem>
+            <Link href="/library">Digital Library</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Text>{buildingType}</Text>
+          </BreadcrumbItem>
+        </Breadcrumb>
+        <Box flex="1"></Box>
+        <SearchBar
+          handleSearch={handleSearch}
+          resetSearch={resetSearch}
+          tagToClear={tagToClear}
+          setTagToClear={setTagToClear}
+          setResetSearch={setResetSearch}
+        />
+      </HStack>
+      <CurrentSearchInfo
+        handleSearch={handleSearch}
+        searchString={searchString}
+        location={buildingType}
+        tags={tags}
+        setResetSearch={setResetSearch}
+        setTagToClear={setTagToClear}
+      />
       {cards.length > 0 ? (
         <StandardCardTable cards={cards} setCards={setCards} />
       ) : (
-        <Flex flexWrap="wrap" gap="4rem">
+        <Flex flexWrap="wrap" gap="4rem" mt="2rem">
           <CategoryCards routerQuery={router.query} />
         </Flex>
       )}


### PR DESCRIPTION
## ah/117-filter-search-by-tags

Issue Number(s): #117 

What does this PR change and why?

- add search by tags functionality
- move search bar line to be on same line as breadcrumbs
- box which shows current search criteria
- fixed flashing bug (had to do with Chakra Popover being larger in height than the window, but I had to switch to a tab component anyways to match the Figma. if you see weird position: absolutes, it's because the tab component was pushing elements around when open)

### Checklist

**Before Clicking Search**
- [ ] Tag Selection component opens onClick of "Filter Button"
- [ ] onCheck of a tag adds that tag to the search filter 
- [ ] onCheck of tag updates the Filter button to reflect the number of tags to be filtered by 

**After Clicking Search**
- [ ] onSearch, the relevant cards are shown that match both the tags and/or the search string
- [ ] Renders, you searched for "x" in "primaryCategory name" 
- [ ] able to deselect by clicking x or clicking "clear all"

**Frontend**
- [ ] The dropdown is seamless just like in the figma. Currently, there is a flash/lag when the dropdown is clicked


### How to Test

- test filtering on a building type and primary category page
- note: if it's not intended that every filtered tag must be in the card (ie: if we should search for all cards with any of the tags) then that will need to be changed in the backend
