### PR TITLE
ah/130-tag-addition-edit-standard

### DIFF
--- a/server/mongodb/actions/Tag.js
+++ b/server/mongodb/actions/Tag.js
@@ -3,7 +3,6 @@ import Tag from "../models/Tag";
 
 export async function createTag({ name }) {
   await mongoDB();
-  name = name.toLowerCase();
   const tag = await Tag.create({ name });
   return tag;
 }
@@ -26,7 +25,7 @@ export async function getTagsObject() {
   const tag = await Tag.aggregate([
     {
       $group: {
-        _id: { $substr: ["$name", 0, 1] },
+        _id: { $toLower: { $substr: ["$name", 0, 1] } },
         tags: {
           $push: {
             id: "$_id",

--- a/server/mongodb/actions/User/ActiveReport.js
+++ b/server/mongodb/actions/User/ActiveReport.js
@@ -4,9 +4,9 @@ import User from "../../models/User";
 const populateString = "activeReport.cards.card";
 
 const removeNullCards = (report) => {
-  report.cards = report.cards.filter(card => card.card !== null);
+  report.cards = report.cards.filter((card) => card.card !== null);
   return report;
-}
+};
 
 export const getActiveReport = async (userId) => {
   try {

--- a/server/mongodb/actions/User/ActiveReport.js
+++ b/server/mongodb/actions/User/ActiveReport.js
@@ -15,7 +15,9 @@ export const getActiveReport = async (userId) => {
     if (user == null) {
       throw new Error();
     }
-    return user.activeReport ? removeNullCards(user.activeReport) : user.activeReport;
+    return user.activeReport
+      ? removeNullCards(user.activeReport)
+      : user.activeReport;
   } catch (e) {
     console.log(e);
   }

--- a/server/mongodb/actions/User/ActiveReport.js
+++ b/server/mongodb/actions/User/ActiveReport.js
@@ -15,7 +15,7 @@ export const getActiveReport = async (userId) => {
     if (user == null) {
       throw new Error();
     }
-    return removeNullCards(user.activeReport);
+    return user.activeReport ? removeNullCards(user.activeReport) : user.activeReport;
   } catch (e) {
     console.log(e);
   }

--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -15,11 +15,13 @@ import {
   ModalOverlay,
   Tag,
   Text,
-  useDisclosure,
   Wrap,
+  useDisclosure,
 } from "@chakra-ui/react";
+import urls from "lib/utils/urls";
 import { useEffect, useState } from "react";
 import { useFormState } from "react-final-form";
+import useSWR from "swr";
 import useActiveReport from "../../../lib/hooks/useActiveReport";
 import useUser from "../../../lib/hooks/useUser";
 import ArrowIcon from "../../Carousel/ArrowIcon";
@@ -80,8 +82,17 @@ const CardModal = ({
     onClose: onDeleteImageClose,
   } = useDisclosure();
 
+  const {
+    isOpen: isTagDoesNotExistOpen,
+    onOpen: onTagDoesNotExistOpen,
+    onClose: onTagDoesNotExistClose,
+  } = useDisclosure();
+
   const [editing, setEditing] = useState(false);
   const { user } = useUser();
+
+  const { data } = useSWR(urls.api.tag.getObject);
+  const dbTags = data?.payload[0];
 
   const [selectedImage, setSelectedImage] = useState(0);
 
@@ -178,6 +189,33 @@ const CardModal = ({
     setValue("images", newCardImages);
     setImagesToDelete((imagesToDelete) => [...imagesToDelete, image]);
     onDeleteImageClose();
+  };
+
+  const addNewTag = () => {
+    const existingTags = JSON.parse(JSON.stringify(form.values.tags))
+      ? JSON.parse(JSON.stringify(form.values.tags))
+      : [];
+    existingTags.push(form.values.newTag.trim());
+    setValue("newTag", "");
+    setValue("tags", existingTags);
+  };
+
+  const validateNewTag = () => {
+    if (form.values.tags.includes(form.values?.newTag)) {
+      setValue("newTag", "");
+      return;
+    }
+    if (form.values?.newTag?.trim().length > 0) {
+      const firstLetter = form.values.newTag.charAt(0).toLowerCase();
+      if (dbTags[firstLetter]) {
+        const foundTag = dbTags[firstLetter].find(
+          (obj) => obj.name === form.values.newTag
+        );
+        foundTag ? addNewTag() : onTagDoesNotExistOpen();
+      } else {
+        onTagDoesNotExistOpen();
+      }
+    }
   };
 
   const form = useFormState();
@@ -423,16 +461,7 @@ const CardModal = ({
                       onKeyDown={(e) => {
                         if (e.code == "Enter") {
                           if (form.values.newTag?.length > 0) {
-                            const existingTags = JSON.parse(
-                              JSON.stringify(form.values.tags)
-                            )
-                              ? JSON.parse(JSON.stringify(form.values.tags))
-                              : [];
-                            if (form.values?.newTag?.trim().length > 0) {
-                              existingTags.push(form.values.newTag.trim());
-                              setValue("newTag", "");
-                              setValue("tags", existingTags);
-                            }
+                            validateNewTag();
                           }
                         }
                       }}
@@ -448,18 +477,7 @@ const CardModal = ({
                       size="xl"
                       border="solid 2px black"
                       _hover={{ bgColor: "#f0f0f0" }}
-                      onClick={() => {
-                        const existingTags = JSON.parse(
-                          JSON.stringify(form.values.tags)
-                        )
-                          ? JSON.parse(JSON.stringify(form.values.tags))
-                          : [];
-                        if (form.values?.newTag?.trim().length > 0) {
-                          existingTags.push(form.values.newTag.trim());
-                          setValue("newTag", "");
-                          setValue("tags", existingTags);
-                        }
-                      }}
+                      onClick={validateNewTag}
                     >
                       <ArrowUpIcon h={4} w={4} color="black" />
                     </Button>
@@ -554,6 +572,17 @@ const CardModal = ({
         confirmActionText="Yes, delete standard"
         abandonActionText="No, return to edit"
         colorScheme="red"
+      />
+      <ConfirmActionsModal
+        isOpen={isTagDoesNotExistOpen}
+        onClose={onTagDoesNotExistClose}
+        handleAction={() => {
+          addNewTag();
+          onTagDoesNotExistClose();
+        }}
+        subcontent={`"${form.values.newTag}" doesn't currently exist as a tag. Would you like to create it?`}
+        confirmActionText="Yes, create tag."
+        abandonActionText="No, return to edit."
       />
     </Modal>
   );

--- a/src/components/Modals/CardModal/CardModalWithForm.jsx
+++ b/src/components/Modals/CardModal/CardModalWithForm.jsx
@@ -9,10 +9,9 @@ import {
   updateCardById,
 } from "../../../actions/Card";
 
-import { deleteFile } from "src/lib/utils/blobStorage";
 import { createTag } from "../../../actions/Tag";
-import CardModal from "./CardModal";
 import cardEditValidator from "./cardEditValidator";
+import CardModal from "./CardModal";
 
 const CardModalWithForm = ({
   card,
@@ -23,6 +22,8 @@ const CardModalWithForm = ({
   ...rest
 }) => {
   const router = useRouter();
+
+  // eslint-disable-next-line no-unused-vars
   const [imagesToDelete, setImagesToDelete] = useState([]);
 
   const { data } = useSWR(urls.api.tag.getObject);
@@ -38,9 +39,10 @@ const CardModalWithForm = ({
       return obj;
     }, {});
 
-    for (let i = 0; i < imagesToDelete.length; i++) {
-      await deleteFile(imagesToDelete[i]);
-    }
+    // this deletes the image from blob (but this image could be referenced in other cards!! thus making images appear null)
+    // for (let i = 0; i < imagesToDelete.length; i++) {
+    //   await deleteFile(imagesToDelete[i]);
+    // }
 
     const newTagsToAdd = dirtyValues.tags?.filter((tag) => {
       const firstLetter = tag.charAt(0).toLowerCase();
@@ -74,12 +76,13 @@ const CardModalWithForm = ({
 
     mutate(urls.api.user.activeReport.get);
 
-    setImagesToDelete([]);
-    revalidate(JSON.stringify([router.asPath]));
+    // setImagesToDelete([]);
+    await revalidate(JSON.stringify([router.asPath]));
   };
 
   const handleDeleteStandard = async () => {
     await deleteCardById(card._id);
+    await revalidate(JSON.stringify([router.asPath]));
     let newCards = [];
     for (let oldCardIndex in cards) {
       if (cards[oldCardIndex]._id !== card._id) {

--- a/src/components/Modals/CardModal/CardModalWithForm.jsx
+++ b/src/components/Modals/CardModal/CardModalWithForm.jsx
@@ -72,6 +72,8 @@ const CardModalWithForm = ({
       });
     });
 
+    mutate(urls.api.user.activeReport.get);
+
     setImagesToDelete([]);
     revalidate(JSON.stringify([router.asPath]));
   };

--- a/src/components/Modals/CardModal/cardEditValidator.js
+++ b/src/components/Modals/CardModal/cardEditValidator.js
@@ -1,4 +1,5 @@
 import { isValidBlobUrl } from "src/lib/utils/blobStorage";
+import { DEFAULT_IMAGE } from "src/lib/utils/constants";
 
 const cardEditValidator = (values) => {
   const errors = {};
@@ -13,7 +14,9 @@ const cardEditValidator = (values) => {
       errors.images = "One image minimum is required";
     }
     for (let image of values.images) {
-      if (!isValidBlobUrl(image.imageUrl)) {
+      if (
+        !(isValidBlobUrl(image.imageUrl) || image.imageUrl === DEFAULT_IMAGE)
+      ) {
         errors.images = "An image has an invalid url";
       }
     }

--- a/src/components/Modals/DeleteImageModal.jsx
+++ b/src/components/Modals/DeleteImageModal.jsx
@@ -1,5 +1,6 @@
 import { Heading, VStack } from "@chakra-ui/react";
 import Image from "next/image";
+import { DEFAULT_IMAGE } from "src/lib/utils/constants";
 import ConfirmActionModal from "./ConfirmActionModal/ConfirmActionModal";
 
 const DeleteImageModal = ({
@@ -28,7 +29,7 @@ const DeleteImageModal = ({
           {image.name}
         </Heading>
         <Image
-          src="https://user-images.githubusercontent.com/69729390/214123449-126291c9-2cde-4773-90b7-a54a38336553.png"
+          src={DEFAULT_IMAGE}
           height={125}
           width={125}
           alt="construction image"

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -116,23 +116,25 @@ const NavBar = () => {
       <Box ml="auto" />{" "}
       {/*This is an empty div to right-align the last nav link */}
       <NavLinkAuth />
-      {user?.isLoggedIn && currPage != "/report-builder" && currPage != "/add-standard" && (
-        <>
-          <ShoppingCartView
-            buttonStyles={shoppingCartButtonStyle}
-            isOpen={isCartOpen}
-            onClose={onCartClose}
-          />
+      {user?.isLoggedIn &&
+        currPage != "/report-builder" &&
+        currPage != "/add-standard" && (
+          <>
+            <ShoppingCartView
+              buttonStyles={shoppingCartButtonStyle}
+              isOpen={isCartOpen}
+              onClose={onCartClose}
+            />
 
-          <Button
-            fontSize="lg"
-            onClick={onCartOpen}
-            style={shoppingCartButtonStyle}
-          >
-            {<Icon as={FiChevronsUp} mr="1" fontSize="xl" />} Report Preview
-          </Button>
-        </>
-      )}
+            <Button
+              fontSize="lg"
+              onClick={onCartOpen}
+              style={shoppingCartButtonStyle}
+            >
+              {<Icon as={FiChevronsUp} mr="1" fontSize="xl" />} Report Preview
+            </Button>
+          </>
+        )}
       <ConfirmActionModal
         isOpen={isLogoutOpen}
         onClose={onLogoutClose}

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -116,7 +116,7 @@ const NavBar = () => {
       <Box ml="auto" />{" "}
       {/*This is an empty div to right-align the last nav link */}
       <NavLinkAuth />
-      {currPage != "/report-builder" && currPage != "/add-standard" && (
+      {user?.isLoggedIn && currPage != "/report-builder" && currPage != "/add-standard" && (
         <>
           <ShoppingCartView
             buttonStyles={shoppingCartButtonStyle}

--- a/src/components/RecentStandardsView/LoadedStandards.jsx
+++ b/src/components/RecentStandardsView/LoadedStandards.jsx
@@ -40,7 +40,8 @@ function LoadedStandards(props) {
           setCards(returnedCards);
         });
     }
-  }, [data, props]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   useEffect(() => {
     if (!data && props.standardsData) {

--- a/src/components/ShoppingCartView/ShoppingCartItem.jsx
+++ b/src/components/ShoppingCartView/ShoppingCartItem.jsx
@@ -1,5 +1,6 @@
 import { Box, Button, Divider, Image, Text } from "@chakra-ui/react";
 import React, { useState } from "react";
+import { DEFAULT_IMAGE } from "src/lib/utils/constants";
 
 const ShoppingCartItem = ({
   reportName,
@@ -24,7 +25,7 @@ const ShoppingCartItem = ({
           <Box flex="1" paddingLeft="2.5">
             <Image
               src="../../../public/static/ShoppingCartImg.png"
-              fallbackSrc="https://user-images.githubusercontent.com/69729390/214123449-126291c9-2cde-4773-90b7-a54a38336553.png"
+              fallbackSrc={DEFAULT_IMAGE}
               alt="Shopping Cart Image"
             />
           </Box>

--- a/src/components/ShoppingCartView/ShoppingCartView.jsx
+++ b/src/components/ShoppingCartView/ShoppingCartView.jsx
@@ -25,7 +25,7 @@ const ShoppingCartView = ({ isOpen, onClose, ...rest }) => {
       // this useEffect wrapper prevents jittering
       setSels(report.cards);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating]);
 
   const buttonW = "200px";

--- a/src/components/ShoppingCartView/ShoppingCartView.jsx
+++ b/src/components/ShoppingCartView/ShoppingCartView.jsx
@@ -25,6 +25,7 @@ const ShoppingCartView = ({ isOpen, onClose, ...rest }) => {
       // this useEffect wrapper prevents jittering
       setSels(report.cards);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating]);
 
   const buttonW = "200px";

--- a/src/lib/hooks/useSelectionArray.js
+++ b/src/lib/hooks/useSelectionArray.js
@@ -19,6 +19,7 @@ export default function useSelectionArray(cards) {
       });
       setSelArr(newArr);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating, cards]);
   return { selectionArray: selArr, setSelectionArray: setSelArr };
 }

--- a/src/lib/hooks/useSelectionArray.js
+++ b/src/lib/hooks/useSelectionArray.js
@@ -19,7 +19,7 @@ export default function useSelectionArray(cards) {
       });
       setSelArr(newArr);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating, cards]);
   return { selectionArray: selArr, setSelectionArray: setSelArr };
 }

--- a/src/lib/utils/constants.js
+++ b/src/lib/utils/constants.js
@@ -27,3 +27,6 @@ export const primaryCategoryRoutes = {
   "efficient-lighting-and-applications": "Efficient Lighting and Applications",
   "education-and-operations": "Education and Operations",
 };
+
+export const DEFAULT_IMAGE =
+  "https://user-images.githubusercontent.com/69729390/214123449-126291c9-2cde-4773-90b7-a54a38336553.png";

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -48,7 +48,7 @@ const ReportBuilder = () => {
         }))
       );
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating]);
 
   const handleCompleteReport = async ({ noSave = false }) => {

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Card,
   CardBody,
@@ -6,20 +7,22 @@ import {
   Heading,
   HStack,
   Input,
+  Link,
   StackDivider,
-  VStack,
+  Text,
   useDisclosure,
+  VStack,
 } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
-import { addToArchivedReport } from "../actions/User/ArchivedReport";
 import ArchivedReportView from "src/components/ArchivedReportView";
 import RecentStandardsView from "src/components/RecentStandardsView";
 import { ReportStandard } from "src/components/StandardCard";
 import useActiveReport from "src/lib/hooks/useActiveReport";
+import { addToArchivedReport } from "../actions/User/ArchivedReport";
+import ConfirmActionModal from "../components/Modals/ConfirmActionModal";
 import PrintToPDFButton from "../components/PrintToPDFButton";
 import useUser from "../lib/hooks/useUser";
-import { useRouter } from "next/router";
-import ConfirmActionModal from "../components/Modals/ConfirmActionModal";
 
 const ReportBuilder = () => {
   // For PDF exporting
@@ -45,6 +48,7 @@ const ReportBuilder = () => {
         }))
       );
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isValidating]);
 
   const handleCompleteReport = async ({ noSave = false }) => {
@@ -70,80 +74,109 @@ const ReportBuilder = () => {
   return (
     <>
       <HStack py={10} alignItems="flex-start" spacing={3} px={8}>
-        <VStack
-          flex={2}
-          as={Card}
-          alignItems="flex-start"
-          p={6}
-          spacing={5}
-          divider={<StackDivider color="gray.300" />}
-          rounded={16}
-          border="1px solid"
-          borderColor="gray.300"
-        >
-          <CardBody m={-3} w="100%">
-            <Flex
-              mb={3}
-              width="100%"
-              flexFlow="row nowrap"
-              justifyContent="space-between"
-            >
-              <HStack w="100%">
-                {editingTitle ? ( // temp placeholder condition
-                  <Heading maxW="80%" mr={3}>
-                    Untitiled Report
-                  </Heading>
-                ) : (
-                  <Input
-                    size="lg"
-                    maxW="50%"
-                    fontSize="3xl"
-                    variant="flushed"
-                    mr={3}
-                    placeholder="Title of Current Project Plan"
-                    ref={nameRef}
-                  />
-                )}
-                <Button minW="10%" variant="Grey-outlined-rounded">
-                  Rename
-                </Button>
-              </HStack>
-              <Button
-                minW="20%"
-                position="absolute"
-                right="12"
-                variant="Blue-rounded"
-                onClick={onOpen}
-                isDisabled={report?.cards?.length == 0}
+        {!(sels?.length > 0) ? (
+          <VStack
+            as={Card}
+            alignItems="flex-start"
+            p={6}
+            gap={8}
+            rounded={16}
+            border="1px solid"
+            borderColor="gray.300"
+            height="43em"
+            minW="70%"
+          >
+            <Box>
+              {" "}
+              <Text as="b" fontSize="2xl">
+                Current Report
+              </Text>
+              <Text fontSize="xl">
+                {"You haven’t started building a current report yet. " +
+                  "Browse the digital library to begin adding to your current report."}
+              </Text>
+            </Box>
+            <Link href="/library">
+              <Button variant="Grey-rounded">Browse Digital Library</Button>
+            </Link>
+          </VStack>
+        ) : (
+          <VStack
+            flex={2}
+            as={Card}
+            alignItems="flex-start"
+            p={6}
+            spacing={5}
+            divider={<StackDivider color="gray.300" />}
+            rounded={16}
+            border="1px solid"
+            borderColor="gray.300"
+            minW="70%"
+          >
+            <CardBody m={-3} w="100%">
+              <Flex
+                mb={3}
+                width="100%"
+                flexFlow="row nowrap"
+                justifyContent="space-between"
               >
-                Complete Report
-              </Button>
-              <ConfirmActionModal
-                isOpen={isOpen}
-                onClose={onClose}
-                mainText="Would you like to save this report to Completed Reports"
-                confirmButtonText="Yes, complete and save report"
-                cancelButtonText="No, complete without saving report"
-                handleAction={handleCompleteReport}
-                handleCancelAction={() =>
-                  handleCompleteReport({ noSave: true })
-                }
-                isDanger={false}
-                size="2xl"
-              />
-            </Flex>
-            <PrintToPDFButton report={report} />
-          </CardBody>
-          {sels.map((cardWrapper, index) => (
-            <CardBody pl={3} py={0} key={index}>
-              <ReportStandard
-                card={cardWrapper.card}
-                selState={cardWrapper}
-                useGlobalEditing={useGlobalEditing}
-              />
+                <HStack w="100%">
+                  {editingTitle ? ( // temp placeholder condition
+                    <Heading maxW="80%" mr={3}>
+                      Untitiled Report
+                    </Heading>
+                  ) : (
+                    <Input
+                      size="lg"
+                      maxW="50%"
+                      fontSize="3xl"
+                      variant="flushed"
+                      mr={3}
+                      placeholder="Title of Current Project Plan"
+                      ref={nameRef}
+                    />
+                  )}
+                  <Button minW="10%" variant="Grey-outlined-rounded">
+                    Rename
+                  </Button>
+                </HStack>
+                <Button
+                  minW="20%"
+                  position="absolute"
+                  right="12"
+                  variant="Blue-rounded"
+                  onClick={onOpen}
+                  isDisabled={report?.cards?.length == 0}
+                >
+                  Complete Report
+                </Button>
+                <ConfirmActionModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  mainText="Would you like to save this report to Completed Reports"
+                  confirmButtonText="Yes, complete and save report"
+                  cancelButtonText="No, complete without saving report"
+                  handleAction={handleCompleteReport}
+                  handleCancelAction={() =>
+                    handleCompleteReport({ noSave: true })
+                  }
+                  isDanger={false}
+                  size="2xl"
+                />
+              </Flex>
+              <PrintToPDFButton report={report} />
             </CardBody>
-          ))}
-        </VStack>
+            {sels.map((cardWrapper, index) => (
+              <CardBody pl={3} py={0} key={index}>
+                <ReportStandard
+                  card={cardWrapper.card}
+                  selState={cardWrapper}
+                  useGlobalEditing={useGlobalEditing}
+                />
+              </CardBody>
+            ))}
+          </VStack>
+        )}
         <VStack maxW="35%" flex={1} alignItems="end">
           {user?.isLoggedIn && user?.archivedReports.length > 0 && (
             <Card


### PR DESCRIPTION
## ah/130-tag-addition-edit-standard

Issue Number(s): #130, #135

What does this PR change and why?
- user can add tags right away that already exist in database
- if doesn't exist, user is prompted to create new tag
- duplicates of the same tag can't be added to the same standard
- fixes state not updating in active report when recent standard updated

### Checklist

- [x] Only able to add tags that exist in the Tags Collection (database + tag selection component)
- [x] If trying to add a tag not in the tags collection, prompt a modal to add the tag
- [x] After modal acceptance, tag is added to the card + database + tag selection component


### How to Test

- to any card, add tags "southface", "SouthfacE", and "plumbing" and verify that two new tags are created and plumbing already exists
- newly added tags should appear in filter tag component right away without refreshing / should be able to be added to other cards without prompting to create new tag (might not because SWR mutate is in beta, not sure how else to handle this)
