### PR TITLE
hc/133-report-builder-name-rename

### DIFF
--- a/src/components/PrintToPDFButton/PrintToPDFButton.jsx
+++ b/src/components/PrintToPDFButton/PrintToPDFButton.jsx
@@ -44,11 +44,11 @@ const PrintToPDFButton = (props) => {
   return (
     <HStack>
       <Button
-        as="a"
+        as={props.report?.cards?.length == 0 ? "" : "a"}
         px={4}
         download="UntitledReport"
         variant="Grey-rounded"
-        href={instance.url}
+        href={props.report?.cards?.length == 0 ? "" : instance.url}
         isDisabled={props.report?.cards?.length == 0}
       >
         Download

--- a/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
+++ b/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
@@ -78,7 +78,9 @@ const ReportDocumentPDF = ({ selectedReport }) => {
       <Page size="A4" style={styles.page}>
         <View style={styles.outerContainer}>
           <View style={styles.sectionLarge}>
-            <Text style={styles.title}>*Add title support here</Text>
+            <Text style={styles.title}>
+              {selectedReport.name ?? "Default Report"}
+            </Text>
             <Text style={styles.textSmall}>Completed on ...</Text>
           </View>
           {selectedReport?.cards.map((item, index) => {


### PR DESCRIPTION
## Report Builder's Rename + Report Name in DB

Issue Number(s): #133 

What does this PR change and why?
Adds name + rename functionality and displays new name in pdf.

### Checklist
- [x] Add name property to active report schema (optional value. Can be null). If null, default it to "Untitled Report"
- [x] render the name on the report builder page
- [x] ability to rename + reflect changes on database (name changed on schema) + frontend.

### How to Test
Create a report. See if the default name is displayed in the report builder. Try renaming with long and short names with varying characters. See if those changes are updated on reload and in the PDF. 

### Notes
Bug with re-rendering the updated name right now, waiting for meeting for ideas on how to fix.