### PR TITLE
hc/132 inconsistent browser behavior

### DIFF
--- a/src/components/NavBar/NavLink.jsx
+++ b/src/components/NavBar/NavLink.jsx
@@ -9,17 +9,15 @@ import React from "react";
  */
 const NavLink = ({ href, name, ...rest }) => {
   return href ? (
-    <Link href={href}>
-      <NavButton name={name} href={true} {...rest} />
-    </Link>
+    <NavButton name={name} href={href} {...rest} passHref></NavButton>
   ) : (
     <NavButton name={name} {...rest} />
   );
 };
 
-const NavButton = ({ name, href, children, ...rest }) => (
+const NavButton = ({ name, href, ...rest }) => (
   <Button
-    as={href ? "a" : "button"}
+    as="button"
     color="Grey"
     _hover={{
       color: "Blue",
@@ -35,7 +33,13 @@ const NavButton = ({ name, href, children, ...rest }) => (
     mt={1}
     {...rest}
   >
-    {name || children}
+    {href ? (
+      <Link href={href} passHref>
+        <a>{name}</a>
+      </Link>
+    ) : (
+      name
+    )}
   </Button>
 );
 

--- a/src/components/PrintToPDFButton/PrintToPDFButton.jsx
+++ b/src/components/PrintToPDFButton/PrintToPDFButton.jsx
@@ -44,11 +44,11 @@ const PrintToPDFButton = (props) => {
   return (
     <HStack>
       <Button
-        as="a"
+        as={props.report?.cards?.length == 0 ? "" : "a"}
         px={4}
         download="UntitledReport"
         variant="Grey-rounded"
-        href={instance.url}
+        href={props.report?.cards?.length == 0 ? "" : instance.url}
         isDisabled={props.report?.cards?.length == 0}
       >
         Download

--- a/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
+++ b/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
@@ -78,7 +78,9 @@ const ReportDocumentPDF = ({ selectedReport }) => {
       <Page size="A4" style={styles.page}>
         <View style={styles.outerContainer}>
           <View style={styles.sectionLarge}>
-            <Text style={styles.title}>*Add title support here</Text>
+            <Text style={styles.title}>
+              {selectedReport.name ?? "Default Report"}
+            </Text>
             <Text style={styles.textSmall}>Completed on ...</Text>
           </View>
           {selectedReport?.cards.map((item, index) => {


### PR DESCRIPTION
## Fix bug with opening in a new tab

Issue Number(s): #132 

Link, buttons, and a tag are now in the right order to prevent hydration errors but still allow for right clicking to open in a new tab, and left clicking to use next link.

### Checklist
- [x] Fix right/left click on nav links
- [ ] Do whatever Nabeel said is a problem

### How to Test
- Right and left click on nav links. Right clicks should allow for opening in a new tab, and left clicks should use normal link functionality.
