### PR TITLE
Referencing deleted standards in active report

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     "source.fixAll": true,
     "source.organizeImports": true,
     "source.sortMembers": true
-  }
+  },
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
 }

--- a/server/mongodb/actions/User/ActiveReport.js
+++ b/server/mongodb/actions/User/ActiveReport.js
@@ -4,9 +4,7 @@ import User from "../../models/User";
 const populateString = "activeReport.cards.card";
 
 const removeNullCards = (report) => {
-  console.log(report.cards);
   report.cards = report.cards.filter(card => card.card !== null);
-  console.log(report.cards);
   return report;
 }
 

--- a/server/mongodb/actions/User/ActiveReport.js
+++ b/server/mongodb/actions/User/ActiveReport.js
@@ -3,6 +3,13 @@ import User from "../../models/User";
 
 const populateString = "activeReport.cards.card";
 
+const removeNullCards = (report) => {
+  console.log(report.cards);
+  report.cards = report.cards.filter(card => card.card !== null);
+  console.log(report.cards);
+  return report;
+}
+
 export const getActiveReport = async (userId) => {
   try {
     await mongoDB();
@@ -10,7 +17,7 @@ export const getActiveReport = async (userId) => {
     if (user == null) {
       throw new Error();
     }
-    return user.activeReport;
+    return removeNullCards(user.activeReport);
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
## Referencing deleted standards in active report

Issue Number(s): #136 

This PR introduces a basic method that deletes any cards that don't populate correctly (i.e. don't exist in the database). It is due for some thorough testing, but the basic use case of deleting a card after adding it to an active report is handled.

### How to Test

Try to reproduce the bug as shown in #136
- Log in with admin account
- Add a standard (or use an existing one)
- Add to active report
- Remove that standard
- Note that no errors are shown (hopefully)

Will need further testing for some other edge cases most likely, but this is a start.
