### PR TITLE
rd/106-recentStandardSection

### DIFF
--- a/src/components/RecentStandardsView/LoadedStandards.jsx
+++ b/src/components/RecentStandardsView/LoadedStandards.jsx
@@ -68,7 +68,7 @@ function LoadedStandards(props) {
                 <StandardCard
                   key={index}
                   card={card}
-                  height="90%"
+                  height="80%"
                   selState={selectionArray[index]}
                   cards={cards}
                   setCards={setCards}

--- a/src/components/RecentStandardsView/LoadedStandards.jsx
+++ b/src/components/RecentStandardsView/LoadedStandards.jsx
@@ -68,7 +68,7 @@ function LoadedStandards(props) {
                 <StandardCard
                   key={index}
                   card={card}
-                  height="80%"
+                  height="90%"
                   selState={selectionArray[index]}
                   cards={cards}
                   setCards={setCards}

--- a/src/components/RecentStandardsView/LoadedStandards.jsx
+++ b/src/components/RecentStandardsView/LoadedStandards.jsx
@@ -4,7 +4,7 @@ import urls from "src/lib/utils/urls";
 import useSWRMutation from "swr/mutation";
 import { getCardsByIdsRequest } from "../../actions/Card";
 import useSelectionArray from "../../lib/hooks/useSelectionArray";
-import StandardCard from "../StandardCard";
+import StandardCardSmall from "../StandardCard/StandardCardSmall";
 
 function LoadedStandards(props) {
   const [cards, setCards] = useState([]);
@@ -60,19 +60,18 @@ function LoadedStandards(props) {
   const { selectionArray } = useSelectionArray(cards);
   return (
     <>
-      <HStack height="21rem">
+      <HStack maxH="200px" gap="10px">
         {props.standardsData ? (
           cards.map((card, index) => {
             {
               return (
-                <StandardCard
+                <StandardCardSmall
                   key={index}
                   card={card}
-                  height="80%"
                   selState={selectionArray[index]}
                   cards={cards}
                   setCards={setCards}
-                ></StandardCard>
+                />
               );
             }
           })

--- a/src/components/RecentStandardsView/LoadedStandards.jsx
+++ b/src/components/RecentStandardsView/LoadedStandards.jsx
@@ -68,8 +68,7 @@ function LoadedStandards(props) {
                 <StandardCard
                   key={index}
                   card={card}
-                  height="3rem"
-                  minW="300px"
+                  height="80%"
                   selState={selectionArray[index]}
                   cards={cards}
                   setCards={setCards}

--- a/src/components/RecentStandardsView/RecentStandardsView.jsx
+++ b/src/components/RecentStandardsView/RecentStandardsView.jsx
@@ -14,7 +14,7 @@ function RecentStandardsView({ maxCards }) {
           <Text fontSize="xs">See All Standards</Text>
         </Button>
       </Link>
-      <Flex gap="2rem" overflowX="auto" p={2}>
+      <Flex gap="2rem" overflowX="auto">
         <LoadedStandards
           standardsData={user?.recentStandards}
           maxCards={maxCards}

--- a/src/components/RecentStandardsView/RecentStandardsView.jsx
+++ b/src/components/RecentStandardsView/RecentStandardsView.jsx
@@ -7,7 +7,7 @@ function RecentStandardsView({ maxCards }) {
   const { user } = useUser();
 
   return (
-    <Flex flexDirection={"column"} gap="16px">
+    <Flex flexDirection="column" gap="16px">
       <Heading fontSize="1.5em">Recent Standards</Heading>
       <Link href="/library">
         <Button width="max" variant="Grey-outlined">

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -90,88 +90,91 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   );
 
   return (
-    <Flex
-      {...props}
-      flexDirection="column"
-      boxShadow="base"
-      rounded="23.3173px"
-      overflow="hidden"
-      height="19rem"
-      width="24rem"
-      onClick={onOpenCardModal}
-      _hover={{
-        cursor: "pointer",
-        transition: "0.1s ease-in-out",
-        boxShadow: "xl",
-      }}
-      transition="0.1s ease-in-out"
-    >
-      <Box height="47%" position="relative">
-        <Image
-          height="100%"
-          width="100%"
-          fit="cover"
-          src={card.images[0].imageUrl}
-          alt="construction image"
-        />
-      </Box>
+    <Box {...props}>
+      <Flex
+        flexDirection="column"
+        boxShadow="base"
+        rounded="23.3173px"
+        overflow="hidden"
+        onClick={onOpenCardModal}
+        _hover={{
+          cursor: "pointer",
+          transition: "0.1s ease-in-out",
+          boxShadow: "xl",
+        }}
+        minWidth="24em"
+        maxHeight="20em"
+        width="auto"
+        height="100%"
+        transition="0.1s ease-in-out"
+      >
+        <Box height="50%" flexShrink={1}>
+          <Image
+            fit="cover"
+            src={card.images[0].imageUrl}
+            alt="construction image"
+            height="100%"
+            width="100%"
+          />
+        </Box>
 
-      <Flex p={3} flexDirection="column" flex={1} mx="2">
-        <Heading fontSize="1rem" isTruncated>
-          {card.title}
-        </Heading>
+        <Flex height="50%" p={3} flexDirection="column" flexShrink={1} mx="2">
+          <Heading fontSize="100%" isTruncated flexShrink={1}>
+            {card.title}
+          </Heading>
 
-        <Text
-          fontSize=".92rem"
-          lineHeight="1.2rem"
-          maxHeight="4rem"
-          noOfLines="3"
-        >
-          {card.criteria}
-        </Text>
+          <Text
+            fontSize="90%"
+            lineHeight="1.2em"
+            maxHeight="4em"
+            noOfLines="3"
+            flexShrink={1}
+          >
+            {card.criteria}
+          </Text>
 
-        <HStack
-          mt="auto"
-          mb="0.5"
-          display="flex"
-          justifyContent="space-between"
-        >
-          <Flex overflowX="scroll" flex={1}>
-            {card.tags.map((tag, index) => {
-              if (index < 3) {
-                return (
-                  <Tag
-                    key={index}
-                    textTransform="capitalize"
-                    bgColor="#C4D600"
-                    rounded="14.7877px"
-                    marginLeft={0.5}
-                    flexShrink={0}
-                    display="flex"
-                  >
-                    {tag}
-                  </Tag>
-                );
-              } else {
-                return null;
-              }
-            })}
-          </Flex>
+          <HStack
+            mt="auto"
+            mb="0.5"
+            display="flex"
+            justifyContent="space-between"
+          >
+            <Flex overflowX="auto" flexShrink={0}>
+              {card.tags.map((tag, index) => {
+                if (index < 3) {
+                  return (
+                    <Tag
+                      key={index}
+                      textTransform="capitalize"
+                      bgColor="#C4D600"
+                      rounded="14.7877px"
+                      marginLeft={0.5}
+                      width="auto"
+                    >
+                      {tag}
+                    </Tag>
+                  );
+                } else {
+                  return null;
+                }
+              })}
+            </Flex>
 
-          <ReportButton />
-        </HStack>
+            <ReportButton />
+          </HStack>
 
-        <CardModalWithForm
-          isOpenCardModal={isOpenCardModal}
-          onCloseCardModal={onCloseCardModal}
-          card={card}
-          cards={cards}
-          setCards={setCards}
-          selected={selected}
-          selState={selState}
-        />
+          <CardModalWithForm
+            isOpenCardModal={isOpenCardModal}
+            onCloseCardModal={onCloseCardModal}
+            card={card}
+            cards={cards}
+            setCards={setCards}
+            selected={selected}
+            selState={selState}
+          />
+        </Flex>
       </Flex>
-    </Flex>
+    </Box>
   );
 };
 

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -83,6 +83,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       flexGrow={0}
       flexShrink={0}
       {...props}
+      w="35%"
       isDisabled={user?.isLoggedIn ? false : true}
     >
       {!selected ? "Add To Report" : "Added to Report"}
@@ -115,6 +116,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
             alt="construction image"
             height="100%"
             width="100%"
+            minH="50em"
           />
         </Box>
 
@@ -138,8 +140,9 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
             mb="0.5"
             display="flex"
             justifyContent="space-between"
+            width="100%"
           >
-            <Flex overflowX="auto" flexShrink={0}>
+            <Flex overflowY="auto" flexShrink={0} width="65%">
               {card.tags.map((tag, index) => {
                 if (index < 3) {
                   return (
@@ -149,7 +152,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
                       bgColor="#C4D600"
                       rounded="14.7877px"
                       marginLeft={0.5}
-                      width="auto"
+                      minWidth="max-content"
                     >
                       {tag}
                     </Tag>

--- a/src/components/StandardCard/StandardCardSmall.jsx
+++ b/src/components/StandardCard/StandardCardSmall.jsx
@@ -95,7 +95,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       flexDirection="column"
       boxShadow="base"
       rounded="23.3173px"
-      overflow="hidden" 
+      overflow="hidden"
       onClick={onOpenCardModal}
       _hover={{
         cursor: "pointer",

--- a/src/components/StandardCard/StandardCardSmall.jsx
+++ b/src/components/StandardCard/StandardCardSmall.jsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Flex,
   Heading,
@@ -82,9 +81,9 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       onClick={reportAddHandler}
       flexGrow={0}
       flexShrink={0}
-      whiteSpace="nowrap"
       {...props}
-      w="35%"
+      fontSize="3xs"
+      size="xs"
       isDisabled={user?.isLoggedIn ? false : true}
     >
       {!selected ? "Add To Report" : "Added to Report"}
@@ -92,92 +91,89 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   );
 
   return (
-    <Box {...props}>
-      <Flex
-        flexDirection="column"
-        boxShadow="base"
-        rounded="23.3173px"
-        overflow="hidden"
-        onClick={onOpenCardModal}
-        _hover={{
-          cursor: "pointer",
-          transition: "0.1s ease-in-out",
-          boxShadow: "xl",
-        }}
-        minWidth="24em"
-        maxHeight="20em"
-        width="auto"
-        height="100%"
-        transition="0.1s ease-in-out"
-      >
-        <Box height="50%" flexShrink={1}>
-          <Image
-            fit="cover"
-            src={card.images[0].imageUrl}
-            alt="construction image"
-            height="100%"
-            width="100%"
-          />
-        </Box>
+    <Flex
+      flexDirection="column"
+      boxShadow="base"
+      rounded="23.3173px"
+      overflow="hidden" 
+      onClick={onOpenCardModal}
+      _hover={{
+        cursor: "pointer",
+        transition: "0.1s ease-in-out",
+        boxShadow: "xl",
+      }}
+      w="280px"
+      transition="0.1s ease-in-out"
+      mb={3}
+    >
+      <Image
+        objectFit="cover"
+        src={card.images[0].imageUrl}
+        alt="construction image"
+        boxSize="5em"
+        w="100%"
+      />
 
-        <Flex height="50%" p={3} flexDirection="column" flexShrink={1} mx="2">
-          <Heading fontSize="100%" isTruncated flexShrink={1}>
-            {card.title}
-          </Heading>
+      <Flex height="50%" p={3} flexDirection="column" flexShrink={1} mx="2">
+        <Heading fontSize="xs" isTruncated flexShrink={1}>
+          {card.title}
+        </Heading>
 
-          <Text
-            fontSize="90%"
-            lineHeight="1.2em"
-            maxHeight="4em"
-            noOfLines="3"
-            flexShrink={1}
-          >
-            {card.criteria}
-          </Text>
+        <Text
+          fontSize="2xs"
+          lineHeight="1.2em"
+          maxHeight="4em"
+          noOfLines="3"
+          flexShrink={1}
+        >
+          {card.criteria}
+        </Text>
 
-          <HStack
-            mt="auto"
-            mb="0.5"
-            display="flex"
-            justifyContent="space-between"
-            width="100%"
-          >
-            <Flex overflowY="auto" flexShrink={0} width="65%">
-              {card.tags.map((tag, index) => {
-                if (index < 3) {
-                  return (
-                    <Tag
-                      key={index}
-                      textTransform="capitalize"
-                      bgColor="#C4D600"
-                      rounded="14.7877px"
-                      marginLeft={0.5}
-                      minWidth="max-content"
-                    >
-                      {tag}
-                    </Tag>
-                  );
-                } else {
-                  return null;
-                }
-              })}
-            </Flex>
+        <HStack
+          mb="0.5"
+          display="flex"
+          mt="1"
+          justifyContent="space-between"
+          width="100%"
+          alignContent="center"
+        >
+          <Flex overflowY="auto" flexShrink={0} width="65%">
+            {card.tags.map((tag, index) => {
+              if (index < 3) {
+                return (
+                  <Tag
+                    key={index}
+                    textTransform="capitalize"
+                    fontSize="3xs"
+                    bgColor="#C4D600"
+                    rounded="14.7877px"
+                    marginLeft={0.5}
+                    minWidth="max-content"
+                    size="sm"
+                  >
+                    {tag}
+                  </Tag>
+                );
+              } else {
+                return null;
+              }
+            })}
+          </Flex>
 
-            <ReportButton />
-          </HStack>
+          <ReportButton />
+        </HStack>
 
-          <CardModalWithForm
-            isOpenCardModal={isOpenCardModal}
-            onCloseCardModal={onCloseCardModal}
-            card={card}
-            cards={cards}
-            setCards={setCards}
-            selected={selected}
-            selState={selState}
-          />
-        </Flex>
+        <CardModalWithForm
+          isOpenCardModal={isOpenCardModal}
+          onCloseCardModal={onCloseCardModal}
+          card={card}
+          cards={cards}
+          setCards={setCards}
+          selected={selected}
+          selState={selState}
+        />
       </Flex>
-    </Box>
+    </Flex>
   );
 };
 

--- a/src/components/StandardCardTable/StandardCardTable.jsx
+++ b/src/components/StandardCardTable/StandardCardTable.jsx
@@ -51,6 +51,7 @@ const StandardCardTable = ({ cards, setCards, ...props }) => {
               cards={cards}
               setCards={setCards}
               selState={selArr[index]}
+              height="90%"
             />
           </GridItem>
         ))}

--- a/src/components/StandardCardTable/StandardCardTable.jsx
+++ b/src/components/StandardCardTable/StandardCardTable.jsx
@@ -52,6 +52,7 @@ const StandardCardTable = ({ cards, setCards, ...props }) => {
               setCards={setCards}
               selState={selArr[index]}
               height="90%"
+              w="400px"
             />
           </GridItem>
         ))}

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -83,6 +83,8 @@ const ReportBuilder = () => {
             border="1px solid"
             borderColor="gray.300"
             height="43em"
+            flex={2}
+
           >
             <Box>
               {" "}
@@ -174,12 +176,12 @@ const ReportBuilder = () => {
             ))}
           </VStack>
         )}
-        <VStack maxW="35%" flex={1} alignItems="end">
+        <VStack w="25%" alignItems="end">
           {user?.isLoggedIn && user?.archivedReports.length > 0 && (
             <Card
               boxShadow="none"
-              w="90%"
-              p={4}
+              w="100%"
+              p={5}
               gap={3}
               border="1px solid"
               borderColor="gray.300"
@@ -192,10 +194,12 @@ const ReportBuilder = () => {
           <Card
             boxShadow="none"
             p={5}
-            w="90%"
+            w="100%"
+            h="320px"
             border="1px solid"
             borderColor="gray.300"
             rounded={16}
+            
           >
             <RecentStandardsView maxCards={3} />
           </Card>

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -84,7 +84,6 @@ const ReportBuilder = () => {
             borderColor="gray.300"
             height="43em"
             flex={2}
-
           >
             <Box>
               {" "}
@@ -199,7 +198,6 @@ const ReportBuilder = () => {
             border="1px solid"
             borderColor="gray.300"
             rounded={16}
-            
           >
             <RecentStandardsView maxCards={3} />
           </Card>


### PR DESCRIPTION
[Frontend] Match Recent Standards View Section to Figma 

Issue Number(s): #106 

What does this PR change and why?

### Checklist

- [x] Standard card component is now shrinkable to any size. Make the sizes relative for title, pictures, the card itself
- [x] Scrollable cards inside the section 


### How to Test

Go to report builder
