### PR TITLE
ah/151-search-in-subcategory-broken

### DIFF
--- a/src/pages/api/card/getPagination.js
+++ b/src/pages/api/card/getPagination.js
@@ -9,7 +9,7 @@ const handler = async (req, res) => {
   try {
     const pageNumber = req.query.page - 1;
     const buildingType = req.query.buildingType;
-    const primaryCategory = req.query.primaryCategory;
+    const primaryCategory = req.query.primaryCategory || null;
     const searchFilterString = req.query.searchFilterString || null;
     const searchFilterTags = req.query.searchFilterTags || null;
 
@@ -21,6 +21,8 @@ const handler = async (req, res) => {
       primaryCategory,
     });
     const cardsCount = await getCardsCount({
+      buildingType,
+      primaryCategory,
       searchFilterString,
       searchFilterTags,
     });


### PR DESCRIPTION
## ah/151-search-in-subcategory-broken

Issue Number(s): #151

What does this PR change and why?

- refactored duplicated query code into createSearchQuery() function
- fixed bug: cardCount returning 0 because primaryCategory and buildingType not passed in as parameters
- added card criteria to search checks
- fixed logic so that all searched attributes must match

### Checklist

- [ ] Copy paste checklist from issue.


### How to Test

- test searches in primary category and building type pages and verify expected data based on what is in your database
