### PR TITLE
feat: sort cards alphabetically

### DIFF
--- a/src/components/Notes/Notes.jsx
+++ b/src/components/Notes/Notes.jsx
@@ -29,12 +29,14 @@ const Notes = ({ cardId, notes, ...rest }) => {
       notes: newNotes.map((n) => n).reverse(),
     });
 
-    
-
     updateCard(updatedCard);
 
     const revalidationPaths = JSON.stringify(
-      parseNestedPaths("library", updatedCard.buildingType, updatedCard.primaryCategory)
+      parseNestedPaths(
+        "library",
+        updatedCard.buildingType,
+        updatedCard.primaryCategory
+      )
     );
 
     await revalidate(revalidationPaths);

--- a/src/lib/hooks/useSearch.js
+++ b/src/lib/hooks/useSearch.js
@@ -61,9 +61,13 @@ export default function useSearch({ setNumPages, setCurrentPage, setCards }) {
         searchFilter
       );
 
+      const sortedCards = cards.slice().sort((card1, card2) => {
+        return card1.title.localeCompare(card2.title);
+      });
+
       calculateNumPagesToDisplay(cardsCount);
       setCurrentPage(pageNumber);
-      setCards(cards);
+      setCards(sortedCards);
 
       // shows toast on primary category page if search result not found
       if (cards.length === 0 && primaryCategory == undefined) {

--- a/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
+++ b/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
@@ -26,8 +26,11 @@ import {
 
 const LibraryCategoryPage = (props) => {
   const cardsFromDatabase = props.cardsFromDatabase;
+  const sortedCards = cardsFromDatabase.slice().sort((card1, card2) => {
+    return card1.title.localeCompare(card2.title);
+  });
   const numPagesInitial = props.numPages;
-  const [cards, setCards] = useState(cardsFromDatabase);
+  const [cards, setCards] = useState(sortedCards);
 
   const [currentPage, setCurrentPage] = useState(1);
   const [numPages, setNumPages] = useState(numPagesInitial);


### PR DESCRIPTION
Arrange Standard Cards in Alphabetical Order

Issue Number(s): #174 

What does this PR change and why? Sort cards alphabetically upon viewing and also after searching
