### PR TITLE
Image reordering

### DIFF
--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -210,6 +210,17 @@ const CardModal = ({
     }
   };
 
+  const moveImage = (index, direction) => {
+    const newImages = [...form.values.images];
+    const thisImg = newImages[index];
+    const swapImg = newImages[index + direction];
+
+    newImages[index] = swapImg;
+    newImages[index + direction] = thisImg;
+
+    setValue("images", newImages);
+  };
+
   const form = useFormState();
 
   let discardChangesAndExit = () => {
@@ -355,6 +366,8 @@ const CardModal = ({
                           }
                           cursor={editingReport ? "pointer" : "default"}
                           image={image}
+                          move={(direction) => moveImage(index, direction)}
+                          imageCount={form.values.images.length}
                           openImagePreviewCallback={openImagePreviewCallback}
                           showEnlarge={!editingReport}
                           setCurrentImage={setSelectedImage}

--- a/src/components/Modals/ModalImage/ModalImage.jsx
+++ b/src/components/Modals/ModalImage/ModalImage.jsx
@@ -7,6 +7,8 @@ import ConfirmActionModal from "../CardModal/ConfirmActionModal";
 const ModalImage = ({
   image,
   index = 0,
+  imageCount,
+  move,
   openImagePreviewCallback,
   editing,
   handleDeleteImage,
@@ -32,6 +34,34 @@ const ModalImage = ({
             objectFit="cover"
             alt={"card image"}
           />
+          {editing ? (
+            <Box display="flex" position="absolute" bottom="0" left="0">
+              <Button
+                textAlign="center"
+                bg="blackAlpha.400"
+                backdropFilter="auto"
+                backdropBlur="1px"
+                fontWeight="bold"
+                onClick={() => move(-1)}
+                isDisabled={index === 0}
+              >
+                {"<"}
+              </Button>
+              <Button
+                textAlign="center"
+                bg="blackAlpha.400"
+                backdropFilter="auto"
+                backdropBlur="1px"
+                fontWeight="bold"
+                onClick={() => move(1)}
+                isDisabled={index === imageCount - 1}
+              >
+                {">"}
+              </Button>
+            </Box>
+          ) : (
+            <></>
+          )}
         </Box>
         {editing ? (
           <Button

--- a/src/components/Notes/Notes.jsx
+++ b/src/components/Notes/Notes.jsx
@@ -29,12 +29,14 @@ const Notes = ({ cardId, notes, ...rest }) => {
       notes: newNotes.map((n) => n).reverse(),
     });
 
-    
-
     updateCard(updatedCard);
 
     const revalidationPaths = JSON.stringify(
-      parseNestedPaths("library", updatedCard.buildingType, updatedCard.primaryCategory)
+      parseNestedPaths(
+        "library",
+        updatedCard.buildingType,
+        updatedCard.primaryCategory
+      )
     );
 
     await revalidate(revalidationPaths);


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #169

Add ability for admins to reorder images when editing a card.

https://github.com/GTBitsOfGood/southface/assets/73624015/0042b2e2-7691-4421-bcee-2074bb978771

### Checklist

- [x] Images can be reordered easily within an already created digital library card.
- [x] The reordering also changes the ordering in the backend (the reordering must be persistent, it should not just happen in the frontend).
- [ ] The reordering uses a drag and drop method.
  - This could not be done because the images are stored in a paginated carousel (could only drag-n-drop on the same page)
- [x] Images can only be reordered in "edit" mode.
- [x] The first image in the ordering should become the thumbnail for this card (this should happen automatically but if it doesn't then this will need to be implemented).

### How to Test

1. Find a card that has multiple images and open it
2. Verify that the reorder buttons are not visible
3. Click edit
4. Verify that the reorder buttons are now visible
5. Verify that the first and last images cannot be reordered out of bounds
6. Verify that reordering an image renders properly
7. Verify that discarding changes resets the image order
8. Verify that saving changes persists the new order
