### PR TITLE
ash/168-allowTitleEditing

### DIFF
--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -238,8 +238,12 @@ const CardModal = ({
       <ModalContent rounded={14}>
         <ModalCloseButton right={2} top={0} m={4} />
         <ModalHeader mt={10} mx={6}>
-          <Flex justifyContent="space-between">
-            <Heading mb={2}>{card.title}</Heading>
+          <Flex justifyContent="space-between" align="center" gap={4}>
+            {editing ? (
+              <InputControl name="title" size="lg"></InputControl>
+            ) : (
+              <Heading mb={2}>{card.title}</Heading>
+            )}
             {user?.isAdmin ? (
               !editing ? (
                 <Button

--- a/src/components/Modals/CardModal/cardEditValidator.js
+++ b/src/components/Modals/CardModal/cardEditValidator.js
@@ -3,6 +3,9 @@ import { DEFAULT_IMAGE } from "src/lib/utils/constants";
 
 const cardEditValidator = (values) => {
   const errors = {};
+  if (!values.title || values.title.length == 0) {
+    errors.title = "Title cannot be blank";
+  }
   if (!values.criteria || values.criteria.length == 0) {
     errors.criteria = "Criteria cannot be blank";
   }

--- a/src/components/Notes/Notes.jsx
+++ b/src/components/Notes/Notes.jsx
@@ -29,12 +29,14 @@ const Notes = ({ cardId, notes, ...rest }) => {
       notes: newNotes.map((n) => n).reverse(),
     });
 
-    
-
     updateCard(updatedCard);
 
     const revalidationPaths = JSON.stringify(
-      parseNestedPaths("library", updatedCard.buildingType, updatedCard.primaryCategory)
+      parseNestedPaths(
+        "library",
+        updatedCard.buildingType,
+        updatedCard.primaryCategory
+      )
     );
 
     await revalidate(revalidationPaths);


### PR DESCRIPTION
## Allow Card Titles to be Edited

Issue Number(s): #168

What does this PR change and why?
Made titles for existing cards editable

### Checklist

- [x] Admin can edit the title of a digital library card that has already been created.
- [x] Admin can simply click the title of the card and type into some sort of text book to edit the title.
- [x] Necessary checks on the title input are done.

### How to Test

Login as admin. Click on any existing card and click edit. Should see that title is editable, and an error appears if you attempt to make the title blank. 
