### PR TITLE
fix: align-items center only when editing

### DIFF
--- a/src/components/Modals/CardModal/CardModal.jsx
+++ b/src/components/Modals/CardModal/CardModal.jsx
@@ -238,7 +238,11 @@ const CardModal = ({
       <ModalContent rounded={14}>
         <ModalCloseButton right={2} top={0} m={4} />
         <ModalHeader mt={10} mx={6}>
-          <Flex justifyContent="space-between" align="center" gap={4}>
+          <Flex
+            justifyContent="space-between"
+            align={editing ? "center" : "start"}
+            gap={4}
+          >
             {editing ? (
               <InputControl name="title" size="lg"></InputControl>
             ) : (


### PR DESCRIPTION
## Fix Align-items Center Bug

Issue Number(s): #168 

What does this PR change and why?
Fixes bug where align-items: center is applied in the non-editing view of card. Should only be applied in the editing view.

### Checklist


### How to Test

