### PR TITLE
Match Full Website Designs to Figma

### DIFF
--- a/src/components/BuildingTypeCard/BuildingTypeCard.jsx
+++ b/src/components/BuildingTypeCard/BuildingTypeCard.jsx
@@ -13,7 +13,7 @@ function BuildingTypeCard(props) {
             height="250px"
             objectFit="contain"
           />
-          <Text fontWeight="bold">{props.title}</Text>
+          <Text fontFamily="Roboto Slab">{props.title}</Text>
         </Flex>
       </Link>
     </Flex>

--- a/src/components/CategoryCards/CategoryCard.jsx
+++ b/src/components/CategoryCards/CategoryCard.jsx
@@ -17,11 +17,18 @@ function CategoryCard(props) {
         width="12rem"
         textAlign="center"
         cursor="pointer"
+        paddingTop="1rem"
+        paddingBottom="1rem"
       >
-        <Text fontWeight="extrabold" fontSize="4xl">
+        <Text textAlign="center" textStyle="primaryText">
           {props.initials}
         </Text>
-        <Text paddingX="2rem" fontWeight="semibold" paddingY="1rem">
+        <Text
+          paddingX="1rem"
+          textAlign="center"
+          paddingY="1rem"
+          textStyle="secondaryText"
+        >
           {props.title}
         </Text>
       </Flex>

--- a/src/components/CategoryCards/CategoryCard.jsx
+++ b/src/components/CategoryCards/CategoryCard.jsx
@@ -11,8 +11,8 @@ function CategoryCard(props) {
       <Flex
         direction="column"
         alignItems="center"
-        boxShadow="md"
-        rounded="md"
+        boxShadow="0px 5px 4px rgba(0, 0, 0, 0.2)"
+        rounded="xl"
         height="12rem"
         width="12rem"
         textAlign="center"

--- a/src/components/NavBar/Footer.jsx
+++ b/src/components/NavBar/Footer.jsx
@@ -3,13 +3,13 @@ import { Flex, Image } from "@chakra-ui/react";
 const Footer = () => {
   return (
     <Flex
+      position="relative"
       borderTop="1px solid"
+      marginTop="10vh"
       borderColor="gray.300"
-      height="5vh"
       width="100%"
       justifyContent="center"
       gap="10px"
-      backgroundColor="white"
     >
       <Image
         src="/static/Southface.png"

--- a/src/components/NavBar/Footer.jsx
+++ b/src/components/NavBar/Footer.jsx
@@ -5,7 +5,7 @@ const Footer = () => {
     <Flex
       borderTop="1px solid"
       borderColor="gray.300"
-      height="10vh"
+      height="5vh"
       width="100%"
       justifyContent="center"
       gap="10px"

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -111,6 +111,7 @@ const NavBar = () => {
     borderRadius: borderR + " " + borderR + " 0 0",
   };
 
+  console.log(currPage);
   return (
     <Flex boxShadow="base" py="2">
       <Image
@@ -130,7 +131,7 @@ const NavBar = () => {
           right: 0,
           bottom: 0,
           height: "2px",
-          background: "#00ACC8",
+          background: currPage == "/library" ? "#00ACC8" : "transparent",
         }}
         _hover={{
           _before: {
@@ -139,10 +140,45 @@ const NavBar = () => {
         }}
       />
       {user?.isLoggedIn && (
-        <NavLink name="Report Builder" href={urls.pages.reportbuilder} />
+        <NavLink
+          name="Report Builder"
+          href={urls.pages.reportbuilder}
+          _before={{
+            content: '""',
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: "2px",
+            background:
+              currPage == "/report-builder" ? "#00ACC8" : "transparent",
+          }}
+          _hover={{
+            _before: {
+              background: "#00ACC8",
+            },
+          }}
+        />
       )}
       {user?.isAdmin && (
-        <NavLink name="Add a New Standard" href={urls.pages.addstandard} />
+        <NavLink
+          name="Add a New Standard"
+          href={urls.pages.addstandard}
+          _before={{
+            content: '""',
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: "2px",
+            background: currPage == "/add-standard" ? "#00ACC8" : "transparent",
+          }}
+          _hover={{
+            _before: {
+              background: "#00ACC8",
+            },
+          }}
+        />
       )}
       <Box ml="auto" />{" "}
       {/*This is an empty div to right-align the last nav link */}

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -56,17 +56,31 @@ const NavBar = () => {
           <Box>
             <Flex marginRight={8}>
               <Text
-                fontWeight="light"
-                fontStyle="italic"
+                fontWeight="400"
+                fontStyle="normal"
+                fontFamily="Europa-Regular"
+                fontColor="#6D6E70"
               >{`Logged in as `}</Text>
-              <Text fontWeight="medium" fontStyle="italic" marginLeft={1}>
+              <Text
+                fontWeight="600"
+                fontStyle="regular"
+                marginLeft={1}
+                fontFamily="Europa-Regular"
+                fontColor="#6D6E70"
+              >
                 {user.username}
               </Text>
             </Flex>
           </Box>
 
-          <Divider orientation="vertical" h={6} borderColor="Grey" mr={0} />
-          <NavLink name="Logout" onClick={onLogoutOpen} {...props} />
+          <Divider orientation="vertical" h={6} borderColor="#6D6E70" mr={0} />
+          <NavLink
+            name="Logout"
+            color="#00ACC8"
+            fontWeight="700"
+            onClick={onLogoutOpen}
+            {...props}
+          />
         </Flex>
       );
     }
@@ -106,7 +120,24 @@ const NavBar = () => {
         width="14em"
         right={5}
       />
-      <NavLink name="Digital Library" href={urls.pages.library} />
+      <NavLink
+        name="Digital Library"
+        href={urls.pages.library}
+        _before={{
+          content: '""',
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: "2px",
+          background: "#00ACC8",
+        }}
+        _hover={{
+          _before: {
+            background: "#00ACC8",
+          },
+        }}
+      />
       {user?.isLoggedIn && (
         <NavLink name="Report Builder" href={urls.pages.reportbuilder} />
       )}

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -58,14 +58,14 @@ const NavBar = () => {
               <Text
                 fontWeight="400"
                 fontStyle="normal"
-                fontFamily="Europa-Regular"
+                fontFamily="'Europa-Regular', sans-serif"
                 fontColor="#6D6E70"
               >{`Logged in as `}</Text>
               <Text
                 fontWeight="600"
                 fontStyle="regular"
                 marginLeft={1}
-                fontFamily="Europa-Regular"
+                fontFamily="'Europa-Regular', sans-serif"
                 fontColor="#6D6E70"
               >
                 {user.username}

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -1,28 +1,15 @@
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  Icon,
-  SearchIcon,
-} from "@chakra-ui/icons";
+import { SearchIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
   Flex,
   Input,
   InputGroup,
-  InputLeftAddon,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-  Text,
+  InputLeftElement,
   useDisclosure,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { Form, useForm, useFormState } from "react-final-form";
-import { FaLongArrowAltRight } from "react-icons/fa";
-import Tag from "../Tag";
 
 const SearchBarComponent = (props) => {
   const {
@@ -75,115 +62,45 @@ const SearchBarComponent = (props) => {
       ? `(${values.tagArray.length})`
       : "";
   };
-
   const SearchButton = ({ handleSubmit }) => {
     return (
-      <Button variant="Blue" size="lg" mr="3" onClick={handleSubmit}>
-        <FaLongArrowAltRight />
+      <Button
+        bg="lightgrey"
+        color="black"
+        size="lg"
+        fontSize="18px"
+        onClick={handleSubmit}
+      >
+        Search
       </Button>
     );
   };
 
   return (
     <Flex {...rest} justifyContent="flex-end">
-      {/* search bar */}
-      <Box
-        position="absolute"
-        right={
-          isClickedSearch && values.tagArray && values.tagArray.length > 0
-            ? "15em"
-            : "13em"
-        }
-      >
-        <InputGroup size="lg" borderWidth="">
-          <InputLeftAddon bg="transparent" borderRight="none">
-            <Icon as={SearchIcon} />
-          </InputLeftAddon>
-          <Input
-            value={searchInput}
-            onChange={handleSearchInputChange}
-            placeholder={searchPlaceholder}
-            fontFamily="Europa-Regular"
-            fontWeight="400"
-            fontSize="16px"
-            width="25rem"
-          />
-        </InputGroup>
-      </Box>
+      <Box position="relative">
+        <Flex alignItems="center">
+          {/* search bar */}
+          <InputGroup size="lg">
+            <InputLeftElement pointerEvents="none">
+              <SearchIcon color="lightGrey" />
+            </InputLeftElement>
+            <Input
+              value={searchInput}
+              onChange={handleSearchInputChange}
+              placeholder={searchPlaceholder}
+              fontWeight="400"
+              fontSize="16px"
+              width="25rem"
+              borderRadius="15px"
+              border="2px solid lightGrey"
+            />
+          </InputGroup>
 
-      {/* Filter tab */}
-      <Box mr="3">
-        <Tabs variant="enclosed" h="full" align="end">
-          {isOpen ? (
-            <TabList>
-              <Box
-                border="1px solid Grey"
-                borderBottom="none"
-                roundedTop={8}
-                roundedBottom={0}
-              >
-                <Tab
-                  color="Grey"
-                  bgColor="#F2F2F2"
-                  border="none"
-                  onClick={onToggle}
-                  fontSize="lg"
-                  px={4}
-                  pb={isOpen ? 5 : 3}
-                >
-                  <Text pr={3}>Filter {getNumTagsFiltered(values)}</Text>
-                  <ChevronUpIcon />
-                </Tab>
-              </Box>
-            </TabList>
-          ) : (
-            <Button
-              p={4}
-              pt={3}
-              rounded={8}
-              bgColor="#F2F2F2"
-              color="Grey"
-              border="1px solid Grey"
-              _hover={{ bgColor: "#d9d9d9" }}
-              _active={{ bgColor: "#c1c1c1" }}
-              size="lg"
-              fontSize="lg"
-              onClick={onToggle}
-            >
-              <Text pr={3}>Filter {getNumTagsFiltered(values)}</Text>
-              <ChevronDownIcon />
-            </Button>
-          )}
-          <TabPanels
-            display={isOpen ? "initial" : "none"}
-            backgroundColor="#F2F2F2"
-            mr="-100px"
-          >
-            <TabPanel
-              width={{ base: "75em", "2xl": "80em" }}
-              border="1px solid Grey"
-              rounded={8}
-              roundedTopRight={0}
-              bgColor="#F2F2F2"
-              position="relative"
-            >
-              <Tag height="65vh" overflow="auto" />
-              <Button
-                p={4}
-                variant="Blue"
-                pos="absolute"
-                right="2em"
-                bottom="2em"
-                onClick={() => handleApplyFiltersClick(handleSubmit)}
-              >
-                Apply Filters {getNumTagsFiltered(values)}
-              </Button>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+          {/* Submit search button */}
+          <SearchButton handleSubmit={handleSubmit} />
+        </Flex>
       </Box>
-      {/* Submit search button */}
-      <SearchButton handleSubmit={handleSubmit} />
     </Flex>
   );
 };

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -34,6 +34,7 @@ const SearchBarComponent = (props) => {
     setSearchInput,
     tagToClear,
     setTagToClear,
+    pageType,
     ...rest
   } = props;
 
@@ -41,6 +42,7 @@ const SearchBarComponent = (props) => {
   const { mutators } = useForm();
 
   const { isOpen, onToggle } = useDisclosure();
+  const searchPlaceholder = "Search within " + pageType;
 
   useEffect(() => {
     if (resetSearch) {
@@ -100,7 +102,11 @@ const SearchBarComponent = (props) => {
           <Input
             value={searchInput}
             onChange={handleSearchInputChange}
-            placeholder="Search Cards"
+            placeholder={searchPlaceholder}
+            fontFamily="Europa-Regular"
+            fontWeight="400"
+            fontSize="16px"
+            width="25rem"
           />
         </InputGroup>
       </Box>
@@ -221,6 +227,7 @@ const SearchBar = (props) => {
           isClickedSearch={isClickedSearch}
           searchInput={searchInput}
           setSearchInput={setSearchInput}
+          pageType={props.pageType}
           {...props}
         />
       )}

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -6,7 +6,6 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
-  useDisclosure,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { Form, useForm, useFormState } from "react-final-form";
@@ -16,7 +15,6 @@ const SearchBarComponent = (props) => {
     resetSearch,
     setResetSearch,
     handleSubmit,
-    isClickedSearch,
     searchInput,
     setSearchInput,
     tagToClear,
@@ -28,7 +26,6 @@ const SearchBarComponent = (props) => {
   const { values } = useFormState();
   const { mutators } = useForm();
 
-  const { isOpen, onToggle } = useDisclosure();
   const searchPlaceholder = "Search within " + pageType;
 
   useEffect(() => {
@@ -48,20 +45,10 @@ const SearchBarComponent = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tagToClear, setTagToClear]);
 
-  const handleApplyFiltersClick = (handleSubmit) => {
-    onToggle();
-    handleSubmit();
-  };
-
   const handleSearchInputChange = (e) => {
     setSearchInput(e.target.value);
   };
 
-  const getNumTagsFiltered = (values) => {
-    return isClickedSearch && values.tagArray && values.tagArray.length > 0
-      ? `(${values.tagArray.length})`
-      : "";
-  };
   const SearchButton = ({ handleSubmit }) => {
     return (
       <Button
@@ -69,6 +56,7 @@ const SearchBarComponent = (props) => {
         color="black"
         size="lg"
         fontSize="18px"
+        fontFamily="'Europa-Regular', sans-serif"
         onClick={handleSubmit}
       >
         Search
@@ -91,6 +79,7 @@ const SearchBarComponent = (props) => {
               placeholder={searchPlaceholder}
               fontWeight="400"
               fontSize="16px"
+              fontFamily="'Europa-Regular', sans-serif"
               width="25rem"
               borderRadius="15px"
               border="2px solid lightGrey"

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -53,11 +53,14 @@ const SearchBarComponent = (props) => {
     return (
       <Button
         bg="lightgrey"
-        color="black"
+        color="Grey"
         size="lg"
-        fontSize="18px"
+        fontSize="15px"
+        fontWeight="bold"
         fontFamily="'Europa-Regular', sans-serif"
         onClick={handleSubmit}
+        paddingLeft="2rem"
+        paddingRight="2rem"
       >
         Search
       </Button>

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -116,7 +116,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
         height="100%"
         transition="0.1s ease-in-out"
       >
-        <Box height="50%" flexShrink={1}>
+        <Box height="35%" flexShrink={1}>
           <Image
             fit="cover"
             src={card.images[0].imageUrl}
@@ -126,17 +126,25 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
           />
         </Box>
 
-        <Flex height="50%" p={3} flexDirection="column" flexShrink={1} mx="2">
-          <Heading fontSize="100%" isTruncated flexShrink={1}>
+        <Flex height="60%" p={3} flexDirection="column" flexShrink={1} mx="2">
+          <Heading
+            isTruncated
+            flexShrink={1}
+            fontFamily="Roboto Slab"
+            fontSize="25px"
+            fontWeight="700"
+          >
             {card.title}
           </Heading>
 
           <Text
             fontSize="90%"
             lineHeight="1.2em"
-            maxHeight="4em"
-            noOfLines="3"
+            maxHeight="5em"
+            noOfLines="4"
             flexShrink={1}
+            textStyle="secondaryTextStandard"
+            paddingBottom="2rem"
           >
             {card.criteria}
           </Text>
@@ -146,6 +154,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
             mb="0.5"
             display="flex"
             justifyContent="space-between"
+            height="5%"
             width="100%"
           >
             <Flex overflowY="auto" flexShrink={0} width="65%">
@@ -155,7 +164,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
                     <Tag
                       key={index}
                       textTransform="capitalize"
-                      bgColor="#C4D600"
+                      bgColor="#E2E3E5"
                       rounded="14.7877px"
                       marginLeft={0.5}
                       minWidth="max-content"

--- a/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
+++ b/src/pages/library/[buildingType]/[primaryCategory]/index.jsx
@@ -6,6 +6,7 @@ import {
   Flex,
   HStack,
   Text,
+  useTheme,
 } from "@chakra-ui/react";
 import Link from "next/link";
 import { useState } from "react";
@@ -25,6 +26,7 @@ import {
 } from "src/lib/utils/utilFunctions";
 
 const LibraryCategoryPage = (props) => {
+  const theme = useTheme();
   const cardsFromDatabase = props.cardsFromDatabase;
   const sortedCards = cardsFromDatabase.slice().sort((card1, card2) => {
     return card1.title.localeCompare(card2.title);
@@ -53,20 +55,38 @@ const LibraryCategoryPage = (props) => {
     <Flex alignItems="stretch" flexDirection="column" p="2rem">
       <HStack w="full" position="relative">
         <Breadcrumb
-          separator=">"
+          separator="/"
           fontWeight="semibold"
           position="absolute"
           top={2}
         >
-          <BreadcrumbItem>
+          <BreadcrumbItem
+            style={{
+              color: theme.colors.lightGrey,
+              fontFamily: theme.fonts.heading,
+              fontWeight: theme.fonts.regular,
+            }}
+          >
             <Link href="/library">Digital Library</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem>
+          <BreadcrumbItem
+            style={{
+              color: theme.colors.lightGrey,
+              fontFamily: theme.fonts.heading,
+              fontWeight: theme.fonts.regular,
+            }}
+          >
             <Link href={`/library/${props.params.buildingType}`}>
               {props.buildingType}
             </Link>
           </BreadcrumbItem>
-          <BreadcrumbItem>
+          <BreadcrumbItem
+            style={{
+              color: theme.colors.boldGrey,
+              fontFamily: theme.fonts.headingBold,
+              fontWeight: theme.fonts.bold,
+            }}
+          >
             <Text>{props.primaryCategory}</Text>
           </BreadcrumbItem>
         </Breadcrumb>
@@ -74,6 +94,7 @@ const LibraryCategoryPage = (props) => {
         <Box flex="1"></Box>
 
         <SearchBar
+          pageType={props.primaryCategory}
           handleSearch={handleSearch}
           resetSearch={resetSearch}
           tagToClear={tagToClear}
@@ -81,6 +102,15 @@ const LibraryCategoryPage = (props) => {
           setResetSearch={setResetSearch}
         />
       </HStack>
+
+      <Text
+        fontSize="32px"
+        fontFamily={theme.fonts.body}
+        margin="10px"
+        color={theme.colors.Grey}
+      >
+        {props.primaryCategory}
+      </Text>
 
       <CurrentSearchInfo
         handleSearch={handleSearch}

--- a/src/pages/library/[buildingType]/index.jsx
+++ b/src/pages/library/[buildingType]/index.jsx
@@ -2,11 +2,12 @@ import {
   Box,
   Breadcrumb,
   BreadcrumbItem,
+  BreadcrumbLink,
   Flex,
   HStack,
   Text,
+  useTheme,
 } from "@chakra-ui/react";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { getCardsCount, getCardsPagination } from "server/mongodb/actions/Card";
@@ -19,6 +20,7 @@ import useSearch from "src/lib/hooks/useSearch";
 import { buildingTypeNames } from "src/lib/utils/constants";
 
 function CategoriesPage({ buildingType }) {
+  const theme = useTheme();
   const router = useRouter();
   const [cards, setCards] = useState([]);
   // eslint-disable-next-line no-unused-vars
@@ -43,23 +45,36 @@ function CategoriesPage({ buildingType }) {
   console.log(cards);
 
   return (
-    <Flex padding="2rem" flexDirection="column">
+    <Flex padding="2rem" flexDirection="column" height="78vh">
       <HStack w="full" position="relative">
         <Breadcrumb
-          separator=">"
-          fontWeight="semibold"
+          separator="/"
           position="absolute"
           top={3}
+          style={{ fontSize: "16px" }}
         >
-          <BreadcrumbItem>
-            <Link href="/library">Digital Library</Link>
+          <BreadcrumbItem
+            style={{
+              color: theme.colors.lightGrey,
+              fontFamily: theme.fonts.heading,
+              fontWeight: theme.fonts.regular,
+            }}
+          >
+            <BreadcrumbLink href="/library">Digital Library</BreadcrumbLink>
           </BreadcrumbItem>
-          <BreadcrumbItem>
+          <BreadcrumbItem
+            style={{
+              color: theme.colors.boldGrey,
+              fontFamily: theme.fonts.headingBold,
+              fontWeight: theme.fonts.bold,
+            }}
+          >
             <Text>{buildingType}</Text>
           </BreadcrumbItem>
         </Breadcrumb>
         <Box flex="1"></Box>
         <SearchBar
+          pageType={buildingType}
           handleSearch={handleSearch}
           resetSearch={resetSearch}
           tagToClear={tagToClear}
@@ -67,6 +82,14 @@ function CategoriesPage({ buildingType }) {
           setResetSearch={setResetSearch}
         />
       </HStack>
+      <Text
+        fontSize="32px"
+        fontFamily={theme.fonts.body}
+        margin="10px"
+        color={theme.colors.Grey}
+      >
+        {buildingType}
+      </Text>
       <CurrentSearchInfo
         handleSearch={handleSearch}
         searchString={searchString}
@@ -90,7 +113,7 @@ function CategoriesPage({ buildingType }) {
           />
         </>
       ) : (
-        <Flex flexWrap="wrap" gap="4rem" mt="2rem">
+        <Flex flexWrap="wrap" gap="4rem" mt="2rem" marginLeft="5rem">
           <CategoryCards routerQuery={router.query} />
         </Flex>
       )}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -22,9 +22,8 @@ export const southfaceTheme = extendTheme({
   },
   fonts: {
     body: "Roboto Slab",
-    headingBold: "Europa-Bold",
-    heading: "Europa-Regular",
-
+    headingBold: `'Europa-Bold', sans-serif`,
+    heading: `'Europa-Regular', sans-serif`,
     regular: "400",
     bold: "700",
     heavyBold: "800",
@@ -66,12 +65,14 @@ export const southfaceTheme = extendTheme({
       color: "boldGrey",
       fontFamily: "headingBold",
       fontSize: "50px",
+      letterSpacing: "-2px",
     },
     secondaryText: {
       fontSize: "17px",
       fontWeight: "regular",
       fontFamily: "heading",
       color: "Grey",
+      lineHeight: "20px",
     },
 
     // StandardCard.jsx
@@ -94,14 +95,14 @@ export const southfaceTheme = extendTheme({
     name: {
       fontWeight: "400",
       fontStyle: "normal",
-      fontFamily: "Europa-Regular",
+      headingBold: `'Europa-Regular', sans-serif`,
       fontColor: "#6D6E70",
       fontSize: "16px",
     },
     nameBold: {
       fontWeight: "700",
       fontStyle: "normal",
-      fontFamily: "Europa-Bold",
+      headingBold: `'Europa-Bold', sans-serif`,
       fontColor: "#6D6E70",
       fontSize: "16px",
     },

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -14,13 +14,20 @@ export const southfaceTheme = extendTheme({
     darkestBlue: "#006779",
 
     // Grey
+    lightGrey: "#8C8D8F",
     Grey: "#6D6E70",
     darkGrey: "#3F3F3F",
     darkestGrey: "#2D2C2C",
+    boldGrey: "#515254",
   },
   fonts: {
-    body: "Inter, sans-serif",
-    heading: "Inter, sans-serif",
+    body: "Roboto Slab",
+    headingBold: "Europa-Bold",
+    heading: "Europa-Regular",
+
+    regular: "400",
+    bold: "700",
+    heavyBold: "800",
   },
   breakpoints: {
     xl: "1200px",
@@ -41,6 +48,62 @@ export const southfaceTheme = extendTheme({
         },
         whiteSpace: "trim",
       },
+    },
+  },
+  heading: {
+    customTheme: {
+      fontFamily: "body",
+      fontSize: "24px",
+      fontWeight: "bold",
+      color: "boldGrey",
+      lineHeight: "31.65px",
+    },
+  },
+  textStyles: {
+    // CategoryCard.jsx styles
+    primaryText: {
+      fontWeight: "heavyBold",
+      color: "boldGrey",
+      fontFamily: "headingBold",
+      fontSize: "50px",
+    },
+    secondaryText: {
+      fontSize: "17px",
+      fontWeight: "regular",
+      fontFamily: "heading",
+      color: "Grey",
+    },
+
+    // StandardCard.jsx
+    primaryTextStandard: {
+      fontFamily: "body",
+      fontSize: "24px",
+      fontWeight: "bold",
+      color: "boldGrey",
+      lineHeight: "31.65px",
+    },
+    secondaryTextStandard: {
+      fontFamily: "heading",
+      fontSize: "12px",
+      fontWeight: "regular",
+      color: "Grey",
+      lineHeight: "12px",
+    },
+
+    // NavBar Sign In
+    name: {
+      fontWeight: "400",
+      fontStyle: "normal",
+      fontFamily: "Europa-Regular",
+      fontColor: "#6D6E70",
+      fontSize: "16px",
+    },
+    nameBold: {
+      fontWeight: "700",
+      fontStyle: "normal",
+      fontFamily: "Europa-Bold",
+      fontColor: "#6D6E70",
+      fontSize: "16px",
     },
   },
 });


### PR DESCRIPTION
## [Feature] Match Style and Font Designs to Figma #185

Issue Number(s): close #185 

What does this PR change and why?
- theme styling across nav bar (styling, fonts, pill active state), footer (sizing), CategoryCard (subview) sections (titles, themes, alignment, active breadcrumb), and StandardPage (sub-subview) sections (titles, themes, sizing, active breadcrumb)
- fix missing components and elements
- change search bar props

### Checklist

- [x] Style and font lines up with the Product Designs on Figma


### How to Test

Before (screenshots)
<img width="1487" alt="Screenshot 2023-09-24 at 8 42 44 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/25fbb5de-7e31-40fc-986e-4ffdb4946ef7">

<img width="1486" alt="Screenshot 2023-09-24 at 8 43 03 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/c29cc355-999a-49ed-aa80-3e9091a04226">

<img width="1466" alt="Screenshot 2023-09-24 at 8 43 18 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/c75b01c5-2202-4ab1-9075-857355e72689">





After (screenshots)
<img width="1486" alt="Screenshot 2023-09-24 at 8 29 40 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/6805b867-495a-46a1-8805-d1cf8b665514">

<img width="1494" alt="Screenshot 2023-09-24 at 8 30 03 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/8f7f4cd5-64de-4936-aebd-9c177f059206">

<img width="1480" alt="Screenshot 2023-09-24 at 8 30 54 PM" src="https://github.com/GTBitsOfGood/southface/assets/63896087/1bcefddc-ac4c-40f6-a6c5-492970249991">



