### PR TITLE
feat: change to del button

### DIFF
--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -72,13 +72,15 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   const selected = !selState ? false : true;
 
   // const imgArr = selected ?
-  const { addToReport } = useActiveReport();
+  const { addToReport, removeFromReport } = useActiveReport();
 
   const reportAddHandler = (e) => {
     setAddToReportButtonPressed(true);
     e.stopPropagation(); // stops modal from opening
     if (!selected) {
       addToReport(card);
+    } else {
+      removeFromReport(card);
     }
   };
 
@@ -93,7 +95,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       w="35%"
       isDisabled={user?.isLoggedIn ? false : true}
     >
-      {!selected ? "Add To Report" : "Added to Report"}
+      {!selected ? "Add To Report" : "Del From Report"}
     </Button>
   );
 

--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -32,8 +32,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   );
   const [updateRecentStandardsTriggered, setUpdateRecentStandardsTriggered] =
     useState(false);
-  const [addToReportButtonPressed, setAddToReportButtonPressed] =
-    useState(false);
+  const [addToReportButtonPressed] = useState(false);
 
   useEffect(() => {
     if (
@@ -75,7 +74,9 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   const { addToReport, removeFromReport } = useActiveReport();
 
   const reportAddHandler = (e) => {
-    setAddToReportButtonPressed(true);
+    // We don't need this anymore since we don't want to ever
+    // completely disable the button
+    //setAddToReportButtonPressed(true);
     e.stopPropagation(); // stops modal from opening
     if (!selected) {
       addToReport(card);
@@ -83,21 +84,6 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       removeFromReport(card);
     }
   };
-
-  const ReportButton = ({ ...props }) => (
-    <Button
-      variant={selected ? "Grey" : "Blue-outlined"}
-      onClick={reportAddHandler}
-      flexGrow={0}
-      flexShrink={0}
-      whiteSpace="nowrap"
-      {...props}
-      w="35%"
-      isDisabled={user?.isLoggedIn ? false : true}
-    >
-      {!selected ? "Add To Report" : "Del From Report"}
-    </Button>
-  );
 
   return (
     <Box {...props}>
@@ -149,6 +135,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
             display="flex"
             justifyContent="space-between"
             width="100%"
+            align="stretch"
           >
             <Flex overflowY="auto" flexShrink={0} width="65%">
               {card.tags.map((tag, index) => {
@@ -170,8 +157,18 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
                 }
               })}
             </Flex>
-
-            <ReportButton />
+            <Button
+              variant={selected ? "Grey" : "Blue-outlined"}
+              onClick={reportAddHandler}
+              flexGrow={0}
+              flexShrink={0}
+              whiteSpace="nowrap"
+              // {...props}
+              w="35%"
+              isDisabled={user?.isLoggedIn ? false : true}
+            >
+              {!selected ? "Add To Report" : "Del From Report"}
+            </Button>
           </HStack>
 
           <CardModalWithForm

--- a/src/components/StandardCard/StandardCardSmall.jsx
+++ b/src/components/StandardCard/StandardCardSmall.jsx
@@ -67,11 +67,13 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   const { selState } = { ...props };
   const selected = !selState ? false : true;
   // const imgArr = selected ?
-  const { addToReport } = useActiveReport();
+  const { addToReport, removeFromReport } = useActiveReport();
   const reportAddHandler = (e) => {
     e.stopPropagation(); // stops modal from opening
     if (!selected) {
       addToReport(card);
+    } else {
+      removeFromReport(card);
     }
   };
 
@@ -86,7 +88,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       size="xs"
       isDisabled={user?.isLoggedIn ? false : true}
     >
-      {!selected ? "Add To Report" : "Added to Report"}
+      {!selected ? "Add To Report" : "Del From Report"}
     </Button>
   );
 

--- a/src/components/StandardCard/StandardCardSmall.jsx
+++ b/src/components/StandardCard/StandardCardSmall.jsx
@@ -65,7 +65,7 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
   // editEnable,
   // useEffect on editEnable: make API call after deselecting
   const { selState } = { ...props };
-  const selected = !selState ? false : true;
+  let selected = !selState ? false : true;
   // const imgArr = selected ?
   const { addToReport, removeFromReport } = useActiveReport();
   const reportAddHandler = (e) => {
@@ -76,21 +76,6 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
       removeFromReport(card);
     }
   };
-
-  const ReportButton = ({ ...props }) => (
-    <Button
-      variant={selected ? "Grey" : "Blue-outlined"}
-      onClick={reportAddHandler}
-      flexGrow={0}
-      flexShrink={0}
-      {...props}
-      fontSize="3xs"
-      size="xs"
-      isDisabled={user?.isLoggedIn ? false : true}
-    >
-      {!selected ? "Add To Report" : "Del From Report"}
-    </Button>
-  );
 
   return (
     <Flex
@@ -162,7 +147,19 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
             })}
           </Flex>
 
-          <ReportButton />
+          {/* <ReportButton /> */}
+          <Button
+            variant={selected ? "Grey" : "Blue-outlined"}
+            onClick={reportAddHandler}
+            flexGrow={0}
+            flexShrink={0}
+            {...props}
+            fontSize="3xs"
+            size="sm"
+            isDisabled={user?.isLoggedIn ? false : true}
+          >
+            {!selected ? "Add To Report" : "Del From Report"}
+          </Button>
         </HStack>
 
         <CardModalWithForm


### PR DESCRIPTION
## remove from report button

Issue Number(s): #184 

change added to report button to a remove from report button

### Checklist

- [ ] Button on the card in the digital library itself allows the card to be removed from the report
- [ ] Button replaces the "Add to Report" button since we would only want a card to be removed once it has been added.

### How to Test
Go to standards page and try to delete a standard from the report.
May be buggy.