### PR TITLE
Sl/195 edit report

### DIFF
--- a/src/components/ArchivedReportCard/ArchivedReportCard.jsx
+++ b/src/components/ArchivedReportCard/ArchivedReportCard.jsx
@@ -22,7 +22,11 @@ import defaultReportProps from "./defaultReportProps";
 const ArchivedReportCard = ({ report = defaultReportProps }) => {
   const [hasReportCard, setHasReportCard] = useState(true);
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { isOpen: isOpenEdit, onOpen: onOpenEdit, onClose: onCloseEdit } = useDisclosure();
+  const {
+    isOpen: isOpenEdit,
+    onOpen: onOpenEdit,
+    onClose: onCloseEdit,
+  } = useDisclosure();
   const router = useRouter();
   const { report: activeReport, updateReport } = useActiveReport();
 
@@ -33,7 +37,7 @@ const ArchivedReportCard = ({ report = defaultReportProps }) => {
   };
 
   const handleEdit = () => {
-    const cards = []
+    const cards = [];
     const newReport = { ...report };
     newReport.cards.forEach((card) => {
       cards.push({
@@ -41,11 +45,11 @@ const ArchivedReportCard = ({ report = defaultReportProps }) => {
         imgSelections: Array(card.images.length).fill(true),
         noteSelections: Array(card.notes.length).fill(true),
       });
-    })
+    });
     newReport.cards = cards;
     updateReport(newReport);
     router.push(urls.pages.reportbuilder);
-  }
+  };
 
   return (
     hasReportCard && (
@@ -67,7 +71,14 @@ const ArchivedReportCard = ({ report = defaultReportProps }) => {
                 <PrintToPDFButton report={report} />
               </Box>
               <Box>
-                <Button onClick={activeReport.cards?.length > 0 ? onOpenEdit : handleEdit} marginRight="0.5rem" borderRadius="full" variant="Blue-outlined">
+                <Button
+                  onClick={
+                    activeReport.cards?.length > 0 ? onOpenEdit : handleEdit
+                  }
+                  marginRight="0.5rem"
+                  borderRadius="full"
+                  variant="Blue-outlined"
+                >
                   Edit Report
                 </Button>
                 <Button onClick={onOpen} variant="Red-rounded">

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -21,7 +21,10 @@ import { ReportStandard } from "src/components/StandardCard";
 import useActiveReport from "src/lib/hooks/useActiveReport";
 import urls from "src/lib/utils/urls";
 import useSWR from "swr";
-import { addToArchivedReport, removeArchivedReport } from "../actions/User/ArchivedReport";
+import {
+  addToArchivedReport,
+  removeArchivedReport,
+} from "../actions/User/ArchivedReport";
 import ConfirmActionModal from "../components/Modals/ConfirmActionModal";
 import PrintToPDFButton from "../components/PrintToPDFButton";
 import useUser from "../lib/hooks/useUser";
@@ -44,7 +47,8 @@ const ReportBuilder = () => {
 
   const [sels, setSels] = useState([]);
 
-  const archivedReports = useSWR(urls.api.user.getArchivedReports).data?.payload.archivedReports;
+  const archivedReports = useSWR(urls.api.user.getArchivedReports).data?.payload
+    .archivedReports;
 
   useEffect(() => {
     if (report && !isValidating) {
@@ -83,7 +87,7 @@ const ReportBuilder = () => {
     if (noSave) {
       await addToArchivedReport();
     } else {
-      if (archivedReports.map(report => report._id).includes(report._id)) {
+      if (archivedReports.map((report) => report._id).includes(report._id)) {
         await removeArchivedReport(report._id);
       }
       await addToArchivedReport(report);

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -1,17 +1,17 @@
 import {
+  Box,
   Button,
   Card,
   CardBody,
   Flex,
-  Heading,
   HStack,
-  StackDivider,
-  useDisclosure,
-  VStack,
-  Box,
-  Text,
+  Heading,
   Link,
   Spinner,
+  StackDivider,
+  Text,
+  VStack,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
@@ -19,7 +19,9 @@ import ArchivedReportView from "src/components/ArchivedReportView";
 import RecentStandardsView from "src/components/RecentStandardsView";
 import { ReportStandard } from "src/components/StandardCard";
 import useActiveReport from "src/lib/hooks/useActiveReport";
-import { addToArchivedReport } from "../actions/User/ArchivedReport";
+import urls from "src/lib/utils/urls";
+import useSWR from "swr";
+import { addToArchivedReport, removeArchivedReport } from "../actions/User/ArchivedReport";
 import ConfirmActionModal from "../components/Modals/ConfirmActionModal";
 import PrintToPDFButton from "../components/PrintToPDFButton";
 import useUser from "../lib/hooks/useUser";
@@ -41,6 +43,8 @@ const ReportBuilder = () => {
   const [isLoadingState, setIsLoadingState] = useState(true);
 
   const [sels, setSels] = useState([]);
+
+  const archivedReports = useSWR(urls.api.user.getArchivedReports).data?.payload.archivedReports;
 
   useEffect(() => {
     if (report && !isValidating) {
@@ -79,6 +83,9 @@ const ReportBuilder = () => {
     if (noSave) {
       await addToArchivedReport();
     } else {
+      if (archivedReports.map(report => report._id).includes(report._id)) {
+        await removeArchivedReport(report._id);
+      }
       await addToArchivedReport(report);
     }
 


### PR DESCRIPTION
## Edit report

Issue Number(s): #195 

Adds ability to edit report after completion

### Checklist

- [ ] Reports in the completed reports can be selected and a report builder for that report is pulled up
- [ ] These reports can then be edited and completed again
- [ ] Make sure that the "Print to PDF" reflects the changes (this should happen by default but just make sure)
- [ ] After edits, the report should stay in the completed page


### How to Test

Go to archived reports, click edit report button (2 cases: existing active report or none), edit report, complete report.
