### PR TITLE
ash/210-addToReportVisibility

### DIFF
--- a/src/components/StandardCard/StandardCard.jsx
+++ b/src/components/StandardCard/StandardCard.jsx
@@ -165,18 +165,19 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
                 }
               })}
             </Flex>
-            <Button
-              variant={selected ? "Grey" : "Blue-outlined"}
-              onClick={reportAddHandler}
-              flexGrow={0}
-              flexShrink={0}
-              whiteSpace="nowrap"
-              // {...props}
-              w="35%"
-              isDisabled={user?.isLoggedIn ? false : true}
-            >
-              {!selected ? "Add To Report" : "Del From Report"}
-            </Button>
+            {user?.isLoggedIn && (
+              <Button
+                variant={selected ? "Grey" : "Blue-outlined"}
+                onClick={reportAddHandler}
+                flexGrow={0}
+                flexShrink={0}
+                whiteSpace="nowrap"
+                // {...props}
+                w="35%"
+              >
+                {!selected ? "Add To Report" : "Del From Report"}
+              </Button>
+            )}
           </HStack>
 
           <CardModalWithForm

--- a/src/components/StandardCard/StandardCardSmall.jsx
+++ b/src/components/StandardCard/StandardCardSmall.jsx
@@ -148,18 +148,20 @@ const StandardCard = ({ card, cards, setCards, ...props }) => {
           </Flex>
 
           {/* <ReportButton /> */}
-          <Button
-            variant={selected ? "Grey" : "Blue-outlined"}
-            onClick={reportAddHandler}
-            flexGrow={0}
-            flexShrink={0}
-            {...props}
-            fontSize="3xs"
-            size="sm"
-            isDisabled={user?.isLoggedIn ? false : true}
-          >
-            {!selected ? "Add To Report" : "Del From Report"}
-          </Button>
+          {user?.isLoggedIn && (
+            <Button
+              variant={selected ? "Grey" : "Blue-outlined"}
+              onClick={reportAddHandler}
+              flexGrow={0}
+              flexShrink={0}
+              {...props}
+              fontSize="3xs"
+              size="sm"
+              isDisabled={user?.isLoggedIn ? false : true}
+            >
+              {!selected ? "Add To Report" : "Del From Report"}
+            </Button>
+          )}
         </HStack>
 
         <CardModalWithForm


### PR DESCRIPTION
Remove "Add to Report" Button in Public User View

Issue Number(s): #210 

What does this PR change and why?

Removes the add to report / delete from report button from public view

### Checklist
- [x] Remove add to report button in public view of web app (user has not signed in)
- [x] Add to Report Button should remain in Admin + General User View


### How to Test

In admin mode click on a building type and category with cards. Log out and notice how the add to report button is removed.
