### PR TITLE
Filter images by selection state in report PDF

### DIFF
--- a/src/components/PrintToPDFButton/PrintToPDFButton.jsx
+++ b/src/components/PrintToPDFButton/PrintToPDFButton.jsx
@@ -15,9 +15,9 @@ import { PDFViewer, usePDF } from "@react-pdf/renderer";
 import ReportDocumentPDF from "../ReportDocumentPDF/ReportDocumentPDF";
 
 const PDFWrapper = (props) => {
-  const { report, error } = props;
+  const { report, sels, error } = props;
 
-  if (!report) {
+  if (!report || !sels) {
     return <>Loading...</>;
   }
 
@@ -28,7 +28,7 @@ const PDFWrapper = (props) => {
   return (
     <Flex justifyContent="center" height="max">
       <PDFViewer style={{ height: "70vh", width: "100%" }}>
-        <ReportDocumentPDF selectedReport={report} />
+        <ReportDocumentPDF selectedReport={report} sels={sels} />
       </PDFViewer>
     </Flex>
   );
@@ -68,7 +68,11 @@ const PrintToPDFButton = (props) => {
             <ModalHeader>PDF Preview</ModalHeader>
             <ModalCloseButton />
             <ModalBody>
-              <PDFWrapper error={props.error} report={props.report} />
+              <PDFWrapper
+                error={props.error}
+                report={props.report}
+                sels={props.sels}
+              />
             </ModalBody>
             <ModalFooter>
               <Button variant="Grey-rounded">

--- a/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
+++ b/src/components/ReportDocumentPDF/ReportDocumentPDF.jsx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const ReportDocumentPDF = ({ selectedReport }) => {
+const ReportDocumentPDF = ({ selectedReport, sels }) => {
   return (
     <Document>
       <Page size="A4" style={styles.page}>
@@ -96,6 +96,8 @@ const ReportDocumentPDF = ({ selectedReport }) => {
           </View>
           {selectedReport?.cards.map((item, index) => {
             let card = item.card || item;
+            let imgSelections = (sels || [])[index]?.imgSelections || [];
+
             return (
               <View key={index} styles={styles.card}>
                 <Text style={styles.name}>{card.title}</Text>
@@ -104,37 +106,39 @@ const ReportDocumentPDF = ({ selectedReport }) => {
                   <Text style={styles.text}>{card.criteria}</Text>
                 </View>
                 <View style={styles.imageSetContainer}>
-                  {card?.images.map((image, index) => {
-                    return image ? (
-                      <View
-                        style={[
-                          styles.imageContainer,
-                          {
-                            paddingRight: index % 2 == 0 ? 5 : 0,
-                            paddingLeft: index % 2 == 0 ? 0 : 5,
-                            paddingBottom:
-                              card.images.length % 2 == 0
-                                ? // looks confusing, just replicates the functions of the gap flex property
-                                  index < card.images.length - 2
+                  {card?.images
+                    .filter((_, index) => imgSelections[index])
+                    .map((image, index) => {
+                      return image ? (
+                        <View
+                          style={[
+                            styles.imageContainer,
+                            {
+                              paddingRight: index % 2 == 0 ? 5 : 0,
+                              paddingLeft: index % 2 == 0 ? 0 : 5,
+                              paddingBottom:
+                                card.images.length % 2 == 0
+                                  ? // looks confusing, just replicates the functions of the gap flex property
+                                    index < card.images.length - 2
+                                    ? 10
+                                    : 0
+                                  : index < card.images.length - 1
                                   ? 10
-                                  : 0
-                                : index < card.images.length - 1
-                                ? 10
-                                : 0,
-                          },
-                        ]}
-                        key={index}
-                      >
-                        <Image
-                          src={image.imageUrl}
-                          alt=""
-                          style={styles.image}
-                        ></Image>
-                      </View>
-                    ) : (
-                      <></>
-                    );
-                  })}
+                                  : 0,
+                            },
+                          ]}
+                          key={index}
+                        >
+                          <Image
+                            src={image.imageUrl}
+                            alt=""
+                            style={styles.image}
+                          ></Image>
+                        </View>
+                      ) : (
+                        <></>
+                      );
+                    })}
                 </View>
                 <View style={styles.section}>
                   {card.notes.length > 0 && (

--- a/src/pages/report-builder.jsx
+++ b/src/pages/report-builder.jsx
@@ -4,14 +4,14 @@ import {
   Card,
   CardBody,
   Flex,
-  HStack,
   Heading,
+  HStack,
   Link,
   Spinner,
   StackDivider,
   Text,
-  VStack,
   useDisclosure,
+  VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
@@ -258,7 +258,7 @@ const ReportBuilder = () => {
                   size="2xl"
                 />
               </Flex>
-              <PrintToPDFButton report={report} />
+              <PrintToPDFButton report={report} sels={sels} />
             </CardBody>
             {sels.map((cardWrapper, index) => (
               <CardBody pl={3} py={0} key={index}>


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #188 

Passes the selection state down to the report PDF component, which uses it to filter what images are shown based on the selection state.

### Checklist

- [ ] Images deleted in the report builder do not show up in the completed report
- [ ] Images deleted in the report builder do not show up when the report PDF is downloaded

### How to Test

- Create a report with a card
- Select/de-select images
- Verify that the report PDF reflects the selection state from previously
