### PR TITLE
ash/229-search bar and tags

### DIFF
--- a/server/mongodb/actions/Card.js
+++ b/server/mongodb/actions/Card.js
@@ -55,6 +55,7 @@ function createSearchQuery(
             { title: { $regex: regex } },
             { criteria: { $regex: regex } },
             { "notes.body": { $regex: regex } },
+            { tags: { $regex: regex } },
           ],
         },
         { tags: { $all: searchFilterTags } },
@@ -68,6 +69,7 @@ function createSearchQuery(
         { title: { $regex: regex } },
         { criteria: { $regex: regex } },
         { "notes.body": { $regex: regex } },
+        { tags: { $regex: regex } },
       ],
     };
   } else if (searchFilterTags) {

--- a/server/mongodb/actions/Tag.js
+++ b/server/mongodb/actions/Tag.js
@@ -24,11 +24,6 @@ export async function getTagsObject() {
   // const tag = Tag.find().sort({ name: 1 });
   const tag = await Tag.aggregate([
     {
-      $sort: {
-        name: 1,
-      },
-    },
-    {
       $group: {
         _id: { $toLower: { $substr: ["$name", 0, 1] } },
         tags: {
@@ -49,6 +44,11 @@ export async function getTagsObject() {
     {
       $sort: {
         key: 1,
+      },
+    },
+    {
+      $addFields: {
+        tags: { $sortArray: { input: "$tags", sortBy: { name: 1 } } },
       },
     },
     {

--- a/server/mongodb/actions/Tag.js
+++ b/server/mongodb/actions/Tag.js
@@ -24,6 +24,11 @@ export async function getTagsObject() {
   // const tag = Tag.find().sort({ name: 1 });
   const tag = await Tag.aggregate([
     {
+      $sort: {
+        name: 1,
+      },
+    },
+    {
       $group: {
         _id: { $toLower: { $substr: ["$name", 0, 1] } },
         tags: {


### PR DESCRIPTION
## Search Bar and Tags

Issue Number(s): #229 

What does this PR change and why?

Changes an astounding 7 lines of code to match tag titles as well when searching. Also ensures that tags are alphabetically displayed. 

### Checklist
- [x] If user searches for a keyword, all cards that have the keyword in the title, description, and tags should appear

### How to Test

Try searching for a keyword that's in a card's tags but not in anything else. The search result should also include that card. 
